### PR TITLE
Add docker daemon check to ui_docker_bridge

### DIFF
--- a/weightslab/ui_docker_bridge.py
+++ b/weightslab/ui_docker_bridge.py
@@ -17,11 +17,27 @@ def _get_envoy_config():
 
 
 def _check_docker():
-    """Verify that docker is available."""
+    """Verify that docker is installed and the daemon is running."""
     if shutil.which("docker") is None:
         print(
-            "Error: Docker is required but not found.\n"
+            "Error: Docker is required but not found on your PATH.\n"
             "Install it from: https://docs.docker.com/get-docker/",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        print(
+            "Error: Docker is installed but the daemon is not running.\n"
+            "Start it with:  sudo systemctl start docker\n"
+            "                or open Docker Desktop.",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
Improve error reporting when docker is installed but the daemon is not running, giving the user actionable instructions to start it.