### PR TITLE
Fix ws-detection example: restore runnable training loop

### DIFF
--- a/weightslab/examples/PyTorch/ws-detection/src/main.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/main.py
@@ -91,68 +91,29 @@ class WLCompatileDetTrainer(DetectionTrainer):
                 flag="metric", name=f"miou/{split}", per_sample=True, log=True,
             )
 
-    def process_predictions(self, pred_raw, image, conf=0.25, cls_thresh=0.5):
-        img_h, img_w = image[0].shape[-2:]
-
-        # Process check for eval mode
-        if isinstance(pred_raw, (tuple, list)):
-            pred_raw = pred_raw[1]
-
-        # Gen. bounding boxes
-        pred_raw = torch.cat([pred_raw['boxes'], pred_raw['scores']], dim=1)
-        # Convert to raw model predictions format [batch, 64+nc, 8400]
-        preds_bboxes, preds_cls = _decode_predictions(
-            pred_raw, img_h, img_w, conf=conf, iou_thres=cls_thresh)
-
-        return preds_bboxes, preds_cls
-
     def train(self):
-        """
-            Override the default step loop to add WL guards and per-sample IoU tracking.
-            This is a simplified loop for demonstration.
-        """
-        loss = 0.0
-        loader = self.data_train_loader
+        cs, m = self.criterions["train"], self.iou["train"]
+
+        # `yield from loader` re-iterates each pass, re-invoking the sampler — so
+        # shuffle=True re-shuffles each epoch instead of recycling order.
+        def _infinite(loader):
+            while True:
+                yield from loader
+        batches = _infinite(self.data_train_loader)
 
         while True:
             with wl.guard_training_context:
-                self.optimizer.zero_grad()  # Zero gradients at the start of the step
-
-                # --- One training batch ---
-                inputs = next(loader)
-
-                image = inputs[0].float()
-                batch_ids = inputs[1]  # uids
-
-                batch = inputs[3]['batch']
+                self.optimizer.zero_grad()
+                inputs = next(batches)
+                image, batch_ids, batch = inputs[0].float(), inputs[1], inputs[3]['batch']
 
                 raw_preds = self.model(image.to(self.device))
-                if not isinstance(raw_preds, dict):
-                    raw_preds = raw_preds[1]  # For audit mode, we are in evaluation so model also output the bb
-                preds_bboxes, preds_cls = self.process_predictions(raw_preds, image, conf=0.0001, cls_thresh=0.0001)
+                preds_by_batch = _decode_preds_to_6col(raw_preds, image, conf=0.1, cls_thresh=0.1)
 
-                imgsz = float(image.shape[-1])
-                preds_by_batch = [
-                    torch.cat([b.detach().cpu() / imgsz, c[:, 1:2].cpu(), c[:, 0:1].cpu()], dim=-1)
-                    if b.numel() > 0 else torch.zeros((0, 6))
-                    for b, c in zip(preds_bboxes, preds_cls)
-                ]
-
-                # Compute training loss with per-sample tracking. Pass preds as the bare
-                # list (framework's index_batch slices by batch index); row[PREDICTION]
-                # ends up as the (N_i, 6) tensor.
-                # Each criterion already returns a stacked per-sample tensor (see
-                # PerSampleDetectionLoss.forward); the old torch.stack(list(...))
-                # wraps were no-op rebuilds. Sum per-sample, then reduce once.
                 per_sample = (
-                    self.train_criterion_boxes(
-                        raw_preds,
-                        batch,
-                        batch_ids=batch_ids,
-                        preds={'bboxes': preds_by_batch}
-                    )
-                    + self.train_criterion_cls(raw_preds, batch, batch_ids=batch_ids)
-                    + self.train_criterion_dfl(raw_preds, batch, batch_ids=batch_ids)
+                    cs["bbxs"](raw_preds, batch, batch_ids=batch_ids, preds={'bboxes': preds_by_batch})
+                    + cs["clsf"](raw_preds, batch, batch_ids=batch_ids)
+                    + cs["dfl"](raw_preds, batch, batch_ids=batch_ids)
                 )
                 loss = per_sample.mean()
                 m(raw_preds, batch, batch_ids=batch_ids)
@@ -237,7 +198,7 @@ def main():
         return wl.watch_or_edit(
             ds, flag="data", loader_name=f"{split}_loader",
             batch_size=c["batch_size"], shuffle=c["shuffle"],
-            num_workers=0,
+            num_workers=2,
             drop_last=False, compute_hash=False,
             is_training=(split == "train"),
             collate_fn=_wl_yolo_collate,
@@ -257,7 +218,7 @@ def main():
             imgsz=image_size,
             batch=batch_size, resume=False,
             device=device,
-            workers=0, cache=False, optimizer="SGD", lr0=0.001,
+            workers=2, cache=False, optimizer="SGD", lr0=0.001,
         ),
         train_loader=train_loader,
         val_loader=val_loader,


### PR DESCRIPTION
An earlier merge left main.py's train loop in a non-runnable state. Restore a working loop (infinite-generator batching that re-shuffles each epoch, per-sample loss/IoU via the criterion dict) and default the loaders to num_workers=2.