### PR TITLE
Remove leftover conflict markers in test_data_loader_interface.py

### DIFF
--- a/weightslab/tests/backend/test_data_loader_interface.py
+++ b/weightslab/tests/backend/test_data_loader_interface.py
@@ -359,10 +359,6 @@ class TestDataLoaderInterface(unittest.TestCase):
         total_collected = manual_batches_collected + for_loop_batches_collected
         self.assertGreater(total_collected, batches_per_epoch)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
     def test_epoch_exhausted_flag_behavior(self):
         """Verify internal _epoch_exhausted flag is properly set and reset."""
         # This test directly verifies the lazy reset pattern behavior
@@ -419,11 +415,6 @@ class TestDataLoaderInterface(unittest.TestCase):
         expected_total = epochs * batches_per_epoch
         self.assertEqual(total_batches_collected, expected_total)
 
-=======
->>>>>>> e51a273ebbc415e68cb5c775b12793dc45d80d00
->>>>>>> b675a42d3ee1bb22db6dbfcab6fb1b6ab74acde1
-=======
->>>>>>> 686bb98c727fb594a63b7a14937103edbe2ee55e
 
 class TestDataLoaderReproducibility(unittest.TestCase):
     """Test RNG and iteration state reproducibility for dataloaders."""


### PR DESCRIPTION
## Problem
`main` has unresolved (nested) git conflict markers committed in
`weightslab/tests/backend/test_data_loader_interface.py` (a botched dev->main
merge). This breaks linting/CI for anything based on or merging into `main`.

## Fix
Strip the 9 marker lines only — no logic change. The conflict's only real
content was two test methods (`test_epoch_exhausted_flag_behavior`,
`test_multiple_sequential_epochs_with_auto_reset`), which are preserved.

## Notes
- `git diff` is purely deletions (9 lines); file compiles; no markers remain anywhere in `main`.
- These two tests do **not** exist on `dev`, so `main` will still diverge from `dev` on this file — a future dev->main merge may re-touch this region. Flagging in case you'd rather reconcile with `dev` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)