### PR TITLE
188 logger granularity and structure

### DIFF
--- a/docs/user_functions.rst
+++ b/docs/user_functions.rst
@@ -933,3 +933,113 @@ Export per-instance IoU for a specific box::
         sample_id="img_0042",
         instance_id=1,
     )
+
+write_dataframe
+~~~~~~~~~~~~~~~
+
+**Signature**
+
+.. code-block:: python
+
+   wl.write_dataframe(
+       path=None,
+       format="json",
+       columns=None,
+       sample_id=None,
+       instance_id=None,
+   )
+
+**Purpose**
+
+Dump the WeightsLab sample dataframe to a file for offline analysis.  The
+dataframe holds one row per ``(sample_id, annotation_id)`` pair — sample-level
+metadata sits at ``annotation_id = 0``; per-instance rows (detection boxes,
+segmentation masks) sit at ``annotation_id ≥ 1``.
+
+Before reading, the function calls ``flush()`` on the dataframe manager so any
+pending in-memory writes are persisted first.
+
+**Arguments**
+
+- ``path`` *(str, optional)* — output file path **or** directory.
+
+  - ``None`` (default) — uses ``root_log_dir`` from the active checkpoint
+    manager and auto-generates a filename inside it.
+  - If *path* has a file extension, the file is written directly.
+  - If *path* has no extension or is an existing directory, a filename is
+    **auto-generated** as ``<hash>_dataframe.<format>``, where ``<hash>`` is an
+    8-character MD5 hex digest of the normalized call parameters (*columns*,
+    *sample_id*, *instance_id*).  Same filters → same filename; different
+    filters → different file.
+  - The directory is created automatically if it does not exist.
+
+- ``format`` *({"json", "csv"})* — output format.  Default ``"json"``.
+
+- ``columns`` *(str or list of str, optional)* — which columns to include
+  (index levels ``sample_id`` / ``annotation_id`` are always present):
+
+  - ``None`` / ``"all"`` — every column (default).
+  - ``"tags"`` — only columns prefixed with ``tag:`` (e.g. ``tag:loss_shape``,
+    ``tag:weather``).
+  - ``"signals"`` — only columns prefixed with ``signals`` (per-sample signals
+    logged via ``wl.watch_or_edit`` or ``wl.save_signals``,
+    e.g. ``signals_loss``, ``signals//iou``).
+  - ``"discarded"`` — only the boolean ``discarded`` column.
+  - A list mixing any of the above group names with exact column names.
+
+- ``sample_id`` *(str or list of str, optional)* — restrict to one or more
+  sample IDs (index level 0).  ``None`` keeps all.
+
+- ``instance_id`` *(int or list of int, optional)* — restrict to one or more
+  annotation IDs (index level 1).  ``0`` selects sample-level rows only; ``≥ 1``
+  selects per-instance rows.  ``None`` keeps all.
+
+**JSON output shape**
+
+Each element of the returned JSON array is one row, with ``sample_id`` and
+``annotation_id`` as regular fields:
+
+.. code-block:: json
+
+   [
+     {"sample_id": "img0", "annotation_id": 0, "discarded": false,
+      "tag:loss_shape": "monotonic", "signals_loss": 0.42},
+     {"sample_id": "img0", "annotation_id": 1, "discarded": null,
+      "tag:loss_shape": null, "signals//iou": 0.81}
+   ]
+
+**CSV output shape**
+
+``sample_id`` and ``annotation_id`` appear as the first two columns:
+
+.. code-block:: text
+
+   sample_id,annotation_id,discarded,tag:loss_shape,signals_loss,signals//iou
+   img0,0,False,monotonic,0.42,
+   img0,1,,,,0.81
+
+**Examples**
+
+Dump everything (path inferred from ``root_log_dir``)::
+
+    wl.write_dataframe()
+
+Dump only tags to CSV::
+
+    wl.write_dataframe("tags.csv", format="csv", columns="tags")
+
+Dump signals + discarded flag for two specific samples::
+
+    wl.write_dataframe(
+        "subset.json",
+        columns=["signals", "discarded"],
+        sample_id=["img_001", "img_042"],
+    )
+
+Dump the ``loss_shape`` categorical tag and signals for sample-level rows only
+(``annotation_id = 0``)::
+
+    wl.write_dataframe(
+        columns=["signals", "tag:loss_shape"],
+        instance_id=0,
+    )

--- a/docs/user_functions.rst
+++ b/docs/user_functions.rst
@@ -211,6 +211,113 @@ Advanced example with history (coefficient of variation):
 
        return std_dev / abs(mean)
 
+Real-world example — auto-tagging samples by loss-shape:
+
+A dynamic signal can do more than return a number: it can drive **side effects**
+such as tagging. The example below subscribes to the per-sample classification
+loss ``train/clsf_sample`` and, every 25 steps, looks at each sample's full loss
+trajectory (via :func:`query_sample_history`), classifies its *shape*, and writes
+the verdict back as the categorical tag ``loss_shape`` (via
+:func:`set_categorical_tag`). This turns raw training curves into a filterable,
+sortable label you can triage in the studio — e.g. surface every ``Flat_high``
+sample to hunt for mislabels.
+
+The six shapes:
+
+==============  ====================================================================
+Label           Meaning
+==============  ====================================================================
+monotonic       Loss steadily decreasing — the model is learning the sample.
+plateaued       Decreased then leveled off still-high — stuck / hard sample.
+Flat_high       Never moved, stayed high — likely a mislabel or unlearnable.
+high_variance   Noisy oscillation — model uncertain, often an ambiguous label.
+U_Shape         Learned then forgotten — catastrophic interference from later data.
+Spiked          Sudden jump at some step — data/augmentation/version change.
+==============  ====================================================================
+
+.. code-block:: python
+
+   import numpy as np
+   import weightslab as wl
+
+   LOSS_SHAPE_LABELS = [
+       "monotonic", "plateaued", "Flat_high",
+       "high_variance", "U_Shape", "Spiked",
+   ]
+   LOSS_SHAPE_CODES = {label: i for i, label in enumerate(LOSS_SHAPE_LABELS)}
+
+   def _classify_loss_shape(values):
+       """Classify a per-sample loss trajectory (ordered by step).
+
+       Returns a label string, or None when there is not enough history yet.
+       All thresholds are scale-invariant (fractions of the trajectory's own
+       range) and illustrative — tune them for your own task.
+       """
+       y = np.asarray(values, dtype=float)
+       if y.size < 5:
+           return None
+
+       n = y.size
+       first, last = float(y[0]), float(y[-1])
+       ymin, ymax = float(y.min()), float(y.max())
+       rng = max(ymax - ymin, 1e-8)
+       mean = float(y.mean())
+
+       cv = float(y.std()) / (abs(mean) + 1e-8)        # noisiness
+       drop = (first - last) / (abs(first) + 1e-8)     # net improvement
+       argmin = int(np.argmin(y))
+       rebound = (last - ymin) / rng                    # climb-back from trough
+       max_up_jump = float(np.diff(y).max()) / rng      # largest single-step rise
+
+       tail = y[int(0.6 * n):]
+       tail_flat = (float(tail.std()) / (abs(float(tail.mean())) + 1e-8)) < 0.1
+
+       if max_up_jump > 0.5:
+           return "Spiked"
+       if cv > 0.5:
+           return "high_variance"
+       if 0.2 * n < argmin < 0.8 * n and rebound > 0.3:
+           return "U_Shape"
+       if drop > 0.4:
+           return "monotonic"
+       if drop > 0.15 and tail_flat:
+           return "plateaued"
+       return "Flat_high"
+
+   # Declare the tag up-front so the UI shows all choices (after the dataloader
+   # is registered). Then the signal below populates it during training.
+   wl.register_categorical_tag("loss_shape", LOSS_SHAPE_LABELS)
+
+   @wl.signal(
+       name="loss_shape_classifier",
+       subscribe_to="train/clsf_sample",
+       compute_every_n_steps=25,
+       log=False,  # side-effecting signal: we tag, no aggregate curve needed
+   )
+   def classify_loss_shape(ctx):
+       # Full per-sample trajectory of the subscribed metric, ordered by step.
+       history = wl.query_sample_history(ctx.sample_id, signal_name="train/clsf_sample")
+       series = sorted(((step, val) for _, step, val, _ in history), key=lambda t: t[0])
+       values = [v for _, v in series]
+
+       label = _classify_loss_shape(values)
+       if label is None:
+           return -1
+       wl.set_categorical_tag([ctx.sample_id], "loss_shape", label)
+       return LOSS_SHAPE_CODES[label]
+
+.. note::
+
+   A dynamic signal subscribed to a **per-sample** metric is invoked once per
+   sample in the batch, with ``ctx.sample_id`` and ``ctx.subscribed_value`` set
+   for that sample. ``compute_every_n_steps=25`` throttles it to every 25th step
+   of the subscribed metric. Returning a numeric value (here a shape *code*) lets
+   the verdict also live as a per-sample ``signals//loss_shape_classifier``
+   column; the human-readable label lives on the ``loss_shape`` categorical tag.
+
+   See the detection use case (``examples/PyTorch/ws-detection/src/main.py``) for
+   this signal wired into a real training loop.
+
 compute_signals
 ---------------
 
@@ -585,3 +692,244 @@ optional when ``wl.watch_or_edit`` registrations are in place.
 **Where SignalContext is used**
 
 - In dynamic signals subscribed through ``@wl.signal(subscribe_to=...)``.
+
+Signal history query helpers
+-----------------------------
+
+WeightsLab records three layers of signal history that can be queried at
+any point during or after training:
+
+- **Global history** — one aggregated value per training step (the curve
+  shown in Weights Studio).
+- **Per-sample history** — one value per ``(sample_id, step)`` pair.
+- **Per-instance history** — one value per ``(sample_id, annotation_id, step)``
+  triple (for detection / segmentation tasks).
+
+The functions below give direct access to this data.
+
+get_current_experiment_hash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Signature**
+
+.. code-block:: python
+
+   wl.get_current_experiment_hash() -> str | None
+
+**Purpose**
+
+Return the hash string that identifies the currently active experiment run.
+Reads from the registered checkpoint manager.  Returns ``None`` when no
+experiment is active or no checkpoint manager has been registered yet.
+
+**Example**
+
+.. code-block:: python
+
+   h = wl.get_current_experiment_hash()
+   print(h)  # e.g. "acf5db7dea06963a50f6b7ac"
+
+   # Useful to pin a write_history call to the run currently in progress
+   wl.write_history("/tmp/run", experiment_hash=h)
+
+query_signal_history
+~~~~~~~~~~~~~~~~~~~~
+
+**Signature**
+
+.. code-block:: python
+
+   wl.query_signal_history(signal_name, exp_hash=None) -> list
+
+**Purpose**
+
+Return all per-sample history entries for *signal_name*.
+
+**Returns** a list of ``(sample_id, step, value, experiment_hash)`` tuples.
+Pass *exp_hash* to restrict to a single experiment run.
+
+**Example**
+
+.. code-block:: python
+
+   for sample_id, step, loss, h in wl.query_signal_history("train/loss"):
+       print(sample_id, step, loss)
+
+query_sample_history
+~~~~~~~~~~~~~~~~~~~~
+
+**Signature**
+
+.. code-block:: python
+
+   wl.query_sample_history(sample_id, signal_name=None, exp_hash=None) -> list
+
+**Purpose**
+
+Return the full logged history for a given *sample_id*.
+
+**Returns** a list of ``(signal_name, step, value, experiment_hash)`` tuples.
+Pass *signal_name* to restrict to a single metric.
+
+**Example**
+
+.. code-block:: python
+
+   for sig, step, val, h in wl.query_sample_history("img_0042"):
+       print(sig, step, val)
+
+query_instance_history
+~~~~~~~~~~~~~~~~~~~~~~
+
+**Signature**
+
+.. code-block:: python
+
+   wl.query_instance_history(sample_id, annotation_id,
+                              signal_name=None, exp_hash=None) -> list
+
+**Purpose**
+
+Return the full logged history for a ``(sample_id, annotation_id)``
+instance.  *annotation_id* is 1-based (0 is the per-sample row).
+
+**Returns** a list of ``(signal_name, step, value, experiment_hash)`` tuples.
+
+**Example**
+
+.. code-block:: python
+
+   for sig, step, val, h in wl.query_instance_history("img_0042", annotation_id=1):
+       print(sig, step, val)
+
+write_history
+~~~~~~~~~~~~~
+
+**Signature**
+
+.. code-block:: python
+
+   wl.write_history(
+       path=None,
+       format="json",
+       type_of_history=None,
+       graph_name=None,
+       experiment_hash=None,
+       sample_id=None,
+       instance_id=None,
+   )
+
+**Purpose**
+
+Dump signal history to a file for offline analysis or debugging.
+
+**Arguments**
+
+- ``path`` *(str, optional)* — output file path **or** directory.
+
+  - ``None`` (default) — uses ``root_log_dir`` from the active checkpoint
+    manager (the directory passed to ``wl.watch_or_edit(..., flag="hyperparameters")``
+    or ``wl.watch_or_edit(..., flag="logger", log_dir=...)``) and
+    auto-generates a filename inside it.  Falls back to the current working
+    directory if no checkpoint manager is active.
+  - If *path* points to a file (has an extension), the file is written
+    directly.
+  - If *path* has no extension or is an existing directory, the filename
+    is **auto-generated** as ``<hash>_history.<format>`` inside that
+    directory.  ``<hash>`` is an 8-character hex prefix of the MD5 of the
+    normalized call parameters (*type_of_history*, *graph_name*,
+    *experiment_hash*, *sample_id*, *instance_id*).  Calling the function
+    again with the **same filters** produces the **same filename**
+    (idempotent overwrite); different filters produce different files in
+    the same directory.
+  - The directory is created automatically if it does not exist.
+
+- ``format`` *({"json", "csv"})* — output format.  Default: ``"json"``.
+- ``type_of_history`` *(str or None)* — which layers to include:
+
+  - ``None`` / ``"all"`` — all three layers (global, sample, instance).
+  - ``"global"`` — aggregated training-curve history only.
+  - ``"sample"`` — per-sample history only.
+  - ``"instance"`` / ``"instances"`` — per-instance history only.
+
+- ``graph_name`` *(str or list of str, optional)* — restrict to one or
+  more signal / metric names.
+- ``experiment_hash`` *(str, optional)* — ``None`` (default) uses the
+  current experiment hash from the checkpoint manager.  ``"all"`` includes
+  every hash.  Any other string restricts to that specific run.
+- ``sample_id`` *(str or list of str, optional)* — restrict per-sample and
+  per-instance rows to one or more sample IDs.  Has no effect on global
+  history.
+- ``instance_id`` *(int or list of int, optional)* — restrict per-instance
+  rows to one or more annotation IDs.  Has no effect on global or
+  per-sample history.
+
+**JSON output shape**
+
+.. code-block:: json
+
+   {
+     "global":   [{"graph_name": "loss", "experiment_hash": "h1", "step": 1, "metric_value": 0.42}],
+     "sample":   [{"graph_name": "loss", "experiment_hash": "h1", "sample_id": "img0", "step": 1, "metric_value": 0.38}],
+     "instance": [{"graph_name": "iou",  "experiment_hash": "h1", "sample_id": "img0", "annotation_id": 1, "step": 1, "metric_value": 0.81}]
+   }
+
+Only the sections selected by *type_of_history* are present in the output.
+
+**CSV output shape**
+
+All rows share a common set of columns; fields not applicable to a row
+type are left empty.
+
+.. code-block:: text
+
+   type,graph_name,experiment_hash,step,metric_value,sample_id,annotation_id
+   global,loss,h1,1,0.42,,
+   sample,loss,h1,1,0.38,img0,
+   instance,iou,h1,1,0.81,img0,1
+
+**Examples**
+
+Write all history — directory and filename are inferred automatically
+(most common usage)::
+
+    wl.write_history()   # uses root_log_dir from the checkpoint manager
+
+Write all history to a specific file::
+
+    wl.write_history("history.json")
+
+Write to a directory — filename is auto-generated from a hash of the
+parameters (e.g. ``a3f2b891_history.json``).  Calling with the same
+filters again overwrites the same file::
+
+    wl.write_history(r"C:\tmp\myrun")                # all, current hash
+    wl.write_history(r"C:\tmp\myrun", experiment_hash="all")  # all hashes
+
+Write only per-sample data for experiment ``"abc123"`` to CSV::
+
+    wl.write_history(
+        "run1_samples.csv",
+        format="csv",
+        type_of_history="sample",
+        experiment_hash="abc123",
+    )
+
+Filter by sample and signal::
+
+    wl.write_history(
+        "img0042_loss.json",
+        type_of_history="sample",
+        graph_name="train/loss",
+        sample_id="img_0042",
+    )
+
+Export per-instance IoU for a specific box::
+
+    wl.write_history(
+        "box1.json",
+        type_of_history="instance",
+        graph_name="iou",
+        sample_id="img_0042",
+        instance_id=1,
+    )

--- a/weightslab/__init__.py
+++ b/weightslab/__init__.py
@@ -11,7 +11,7 @@ import os
 import logging
 import threading
 
-from .src import watch_or_edit, start_training, serve, keep_serving, save_signals, save_instance_signals, save_group_signals, tag_samples, register_categorical_tag, set_categorical_tag, discard_samples, get_samples_by_tag, get_discarded_samples, signal, eval_fn, compute_signals, SignalContext, clear_all, run_pending_evaluation, trigger_pending_evaluation_async
+from .src import watch_or_edit, start_training, serve, keep_serving, save_signals, save_instance_signals, save_group_signals, tag_samples, register_categorical_tag, set_categorical_tag, discard_samples, get_samples_by_tag, get_discarded_samples, signal, eval_fn, compute_signals, SignalContext, clear_all, run_pending_evaluation, trigger_pending_evaluation_async, query_signal_history, query_sample_history, query_instance_history, write_history, get_current_experiment_hash
 from .backend.ledgers import GLOBAL_LEDGER as ledger
 from .art import _BANNER
 from .utils.logs import setup_logging, set_log_directory
@@ -106,6 +106,11 @@ __all__ = [
 	"start_training",
 	"register_categorical_tag",
 	"set_categorical_tag",
+    "get_current_experiment_hash",
+    "query_signal_history",
+    "query_sample_history",
+    "query_instance_history",
+    "write_history",
 
     "_BANNER",
     "__version__",

--- a/weightslab/__init__.py
+++ b/weightslab/__init__.py
@@ -11,7 +11,7 @@ import os
 import logging
 import threading
 
-from .src import watch_or_edit, start_training, serve, keep_serving, save_signals, save_instance_signals, save_group_signals, tag_samples, register_categorical_tag, set_categorical_tag, discard_samples, get_samples_by_tag, get_discarded_samples, signal, eval_fn, compute_signals, SignalContext, clear_all, run_pending_evaluation, trigger_pending_evaluation_async, query_signal_history, query_sample_history, query_instance_history, write_history, get_current_experiment_hash
+from .src import watch_or_edit, start_training, serve, keep_serving, save_signals, save_instance_signals, save_group_signals, tag_samples, register_categorical_tag, set_categorical_tag, discard_samples, get_samples_by_tag, get_discarded_samples, signal, eval_fn, compute_signals, SignalContext, clear_all, run_pending_evaluation, trigger_pending_evaluation_async, query_signal_history, query_sample_history, query_instance_history, write_history, write_dataframe, get_current_experiment_hash
 from .backend.ledgers import GLOBAL_LEDGER as ledger
 from .art import _BANNER
 from .utils.logs import setup_logging, set_log_directory
@@ -111,6 +111,7 @@ __all__ = [
     "query_sample_history",
     "query_instance_history",
     "write_history",
+    "write_dataframe",
 
     "_BANNER",
     "__version__",

--- a/weightslab/backend/logger.py
+++ b/weightslab/backend/logger.py
@@ -25,6 +25,23 @@ def _make_per_sample_buf():
     }
 
 
+def _make_per_instance_buf():
+    """Compact storage for per-instance signals: four typed C arrays.
+
+    Fields:
+        sample_ids:      list of str  - dataset sample index
+        annotation_ids:  signed int32 - instance index within sample (1-based)
+        steps:           signed int32 - global training step
+        values:          float32      - signal value at that step for that instance
+    """
+    return {
+        "sample_ids":     [],           # str
+        "annotation_ids": _array('i'),  # int32, 4 bytes each
+        "steps":          _array('i'),  # int32, 4 bytes each
+        "values":         _array('f'),  # float32, 4 bytes each
+    }
+
+
 class LoggerQueue:
     def __init__(self, register: bool = True) -> None:
         self.graph_names = set()
@@ -32,6 +49,12 @@ class LoggerQueue:
         self._last_step = None
         self._signal_history = {}  # Keep all signals in memory for persistence
         self._signal_history_per_sample = {}  # Keep all signals per sample in memory for persistence
+        self._signal_history_per_instance = {}  # Keep all signals per instance in memory for persistence
+        # Reverse indices: O(1) lookup by sample_id or (sample_id, annotation_id)
+        # Structure: {graph_name: {exp_hash: {sample_id: [row_indices]}}}
+        self._sample_index = {}
+        # Structure: {graph_name: {exp_hash: {(sample_id, annotation_id): [row_indices]}}}
+        self._instance_index = {}
         self._pending_queue = []  # Queue for new signals waiting to be sent to WeightsStudio
         self._buffered_step = None
 
@@ -69,6 +92,9 @@ class LoggerQueue:
         # Note: We do not clear graph names here as they are derived from signals and may be needed for future signals after clearing history.
         self._signal_history.clear()
         self._signal_history_per_sample.clear()
+        self._signal_history_per_instance.clear()
+        self._sample_index.clear()
+        self._instance_index.clear()
         self._current_step_buffer.clear()
         self._buffered_step = None
 
@@ -338,10 +364,13 @@ class LoggerQueue:
                     self._signal_history_per_sample[graph_name][eval_hash] = _make_per_sample_buf()
                 buf = self._signal_history_per_sample[graph_name][eval_hash]
                 step_i = int(global_step)
+                idx_map = self._sample_index.setdefault(graph_name, {}).setdefault(eval_hash, {})
                 for sid, value in signal_per_sample.items():
+                    row = len(buf["sample_ids"])
                     buf["sample_ids"].append(sid)
                     buf["steps"].append(step_i)
                     buf["values"].append(self._to_float(value))
+                    idx_map.setdefault(str(sid), []).append(row)
 
             return  # Do NOT add to normal history during evaluation mode
         # ----------------------------------------------------------------
@@ -363,10 +392,13 @@ class LoggerQueue:
 
             buf = self._signal_history_per_sample[graph_name][exp_hash]
             step_i = int(global_step)
+            idx_map = self._sample_index.setdefault(graph_name, {}).setdefault(exp_hash, {})
             for sid, value in signal_per_sample.items():
+                row = len(buf["sample_ids"])
                 buf["sample_ids"].append(sid)
                 buf["steps"].append(step_i)
                 buf["values"].append(self._to_float(value))
+                idx_map.setdefault(str(sid), []).append(row)
 
         metric_values = []
         if isinstance(signal_per_sample, dict) and aggregate_by_step and len(signal_per_sample):
@@ -498,16 +530,20 @@ class LoggerQueue:
         if exp_hash not in self._signal_history_per_sample[graph_name]:
             self._signal_history_per_sample[graph_name][exp_hash] = _make_per_sample_buf()
         buf = self._signal_history_per_sample[graph_name][exp_hash]
+        idx_map = self._sample_index.setdefault(graph_name, {}).setdefault(exp_hash, {})
         seen = set(zip(buf["sample_ids"], buf["steps"]))
         for sid, step, val in triples:
-            key = (str(sid), int(step))
+            sid_s = str(sid)
+            key = (sid_s, int(step))
             if key in seen:
                 continue
-            buf["sample_ids"].append(str(sid))
+            row = len(buf["sample_ids"])
+            buf["sample_ids"].append(sid_s)
             buf["steps"].append(int(step))
             buf["values"].append(float(val))
+            idx_map.setdefault(sid_s, []).append(row)
             seen.add(key)
-            
+
     def get_current_signaL_history_per_sample(self, graph_name: str, sample_ids: list = None, exp_hash: str = None):
         """Get current history for a specific signal."""
         if graph_name not in self._signal_history:
@@ -541,29 +577,229 @@ class LoggerQueue:
             List of (sample_id, step, value, experiment_hash) tuples.
         """
         if graph_name not in self._signal_history_per_sample:
-            return {}
+            return []
 
         exps = self._signal_history_per_sample[graph_name]
         hashes = [exp_hash] if exp_hash is not None else list(exps.keys())
         # Stored ids are ints; callers pass str (df index is str-normalized) — compare as str.
         sid_set = {str(s) for s in sample_ids} if sample_ids is not None else None
 
-        results = {}
+        results = []
         for h in hashes:
             buf = exps.get(h)
             if buf is None:
                 continue
-            for sid, step, val in zip(buf["sample_ids"], buf["steps"], buf["values"]):
-                if sid_set is None or str(sid) in sid_set:
+            if sid_set is None:
+                for sid, step, val in zip(buf["sample_ids"], buf["steps"], buf["values"]):
                     results.append((sid, step, float(val), h))
+            else:
+                idx_map = self._sample_index.get(graph_name, {}).get(h, {})
+                for sid in sid_set:
+                    for row in idx_map.get(sid, []):
+                        results.append((sid, buf["steps"][row], float(buf["values"][row]), h))
 
         return results
+
+    def query_per_instance(
+        self,
+        graph_name: str,
+        sample_id: str | None = None,
+        annotation_id: int | None = None,
+        exp_hash: str | None = None,
+    ) -> list:
+        """Query per-instance signal history.
+
+        Returns a list of ``(sample_id, annotation_id, step, value, exp_hash)``
+        tuples.  Any of *sample_id*, *annotation_id*, *exp_hash* may be ``None``
+        to return all values along that dimension.
+
+        Args:
+            graph_name: Signal name (e.g. ``"confidence"``).
+            sample_id: Filter to a single sample. ``None`` returns all samples.
+            annotation_id: Filter to a single instance (1-based). ``None`` = all.
+            exp_hash: Filter to one experiment hash. ``None`` = all.
+        """
+        if graph_name not in self._signal_history_per_instance:
+            return []
+
+        exps = self._signal_history_per_instance[graph_name]
+        hashes = [exp_hash] if exp_hash is not None else list(exps.keys())
+        sid_filter = str(sample_id) if sample_id is not None else None
+        aid_filter = int(annotation_id) if annotation_id is not None else None
+
+        results = []
+        for h in hashes:
+            buf = exps.get(h)
+            if buf is None:
+                continue
+            if sid_filter is None and aid_filter is None:
+                # No filter: full scan
+                for sid, aid, step, val in zip(
+                    buf["sample_ids"], buf["annotation_ids"], buf["steps"], buf["values"]
+                ):
+                    results.append((str(sid), int(aid), int(step), float(val), h))
+            elif sid_filter is not None and aid_filter is not None:
+                # Both filters: O(1) index lookup
+                idx_map = self._instance_index.get(graph_name, {}).get(h, {})
+                for row in idx_map.get((sid_filter, aid_filter), []):
+                    results.append((sid_filter, aid_filter, int(buf["steps"][row]), float(buf["values"][row]), h))
+            elif sid_filter is not None:
+                # Sample filter only: collect all annotation_ids for this sample
+                idx_map = self._instance_index.get(graph_name, {}).get(h, {})
+                for (sid_k, aid_k), rows in idx_map.items():
+                    if sid_k == sid_filter:
+                        for row in rows:
+                            results.append((sid_filter, aid_k, int(buf["steps"][row]), float(buf["values"][row]), h))
+            else:
+                # annotation_id filter only: scan index keys
+                idx_map = self._instance_index.get(graph_name, {}).get(h, {})
+                for (sid_k, aid_k), rows in idx_map.items():
+                    if aid_k == aid_filter:
+                        for row in rows:
+                            results.append((sid_k, aid_filter, int(buf["steps"][row]), float(buf["values"][row]), h))
+        return results
+
+    def aggregate_per_sample_by_step(
+        self,
+        graph_name: str,
+        sample_ids=None,
+        exp_hash: str | None = None,
+    ) -> dict:
+        """Return mean signal value per step, aggregated over matching samples.
+
+        Uses numpy vectorized operations instead of a Python loop — ~100× faster
+        than iterating ``query_per_sample`` results for large sample counts.
+
+        Args:
+            graph_name: Signal name.
+            sample_ids: Samples to include. ``None`` = all samples.
+            exp_hash: Filter to one experiment hash. ``None`` = all hashes.
+
+        Returns:
+            ``{exp_hash: [(step, mean_value), ...]}`` — one sorted series per hash.
+        """
+        import numpy as _np
+
+        if graph_name not in self._signal_history_per_sample:
+            return {}
+
+        exps = self._signal_history_per_sample[graph_name]
+        hashes = [exp_hash] if exp_hash is not None else list(exps.keys())
+        sid_set = {str(s) for s in sample_ids} if sample_ids is not None else None
+
+        result = {}
+        for h in hashes:
+            buf = exps.get(h)
+            if buf is None:
+                continue
+
+            # Convert typed C arrays to numpy with zero-copy (frombuffer gives a read-only view)
+            steps_np  = _np.frombuffer(buf["steps"],  dtype=_np.int32).copy()
+            values_np = _np.frombuffer(buf["values"], dtype=_np.float32).copy()
+
+            if sid_set is not None:
+                idx_map = self._sample_index.get(graph_name, {}).get(h, {})
+                rows = []
+                for sid in sid_set:
+                    rows.extend(idx_map.get(sid, []))
+                if not rows:
+                    continue
+                row_idx = _np.array(rows, dtype=_np.intp)
+                steps_np  = steps_np[row_idx]
+                values_np = values_np[row_idx]
+
+            if len(steps_np) == 0:
+                continue
+
+            # Vectorized group-by step → mean
+            unique_steps, inverse = _np.unique(steps_np, return_inverse=True)
+            sums   = _np.bincount(inverse, weights=values_np.astype(_np.float64))
+            counts = _np.bincount(inverse)
+            means  = sums / counts
+
+            result[h] = list(zip(unique_steps.tolist(), means.tolist()))
+
+        return result
+
+    def add_instance_scalars(
+        self,
+        graph_name: str,
+        sample_ids,
+        annotation_ids,
+        values,
+        global_step: int,
+        exp_hash: str | None = None,
+    ) -> None:
+        """Record per-instance scalar values in compact storage.
+
+        Call this from ``save_instance_signals`` once per scalar signal per
+        batch.  Each element of *sample_ids*, *annotation_ids*, *values*
+        corresponds to one detection / segmentation instance.
+
+        Args:
+            graph_name: Signal name (e.g. ``"confidence"``).
+            sample_ids: Sequence of sample IDs, one per instance.
+            annotation_ids: Sequence of annotation IDs (1-based), one per instance.
+            values: Scalar values, one per instance (array-like or list).
+            global_step: Current training step.
+            exp_hash: Experiment hash. Resolved from the checkpoint manager if ``None``.
+        """
+        if exp_hash is None:
+            exp_hash = (
+                self.chkpt_manager.get_current_experiment_hash()
+                if self.chkpt_manager
+                else None
+            )
+
+        if graph_name not in self._signal_history_per_instance:
+            self._signal_history_per_instance[graph_name] = {}
+        if exp_hash not in self._signal_history_per_instance[graph_name]:
+            self._signal_history_per_instance[graph_name][exp_hash] = _make_per_instance_buf()
+
+        buf = self._signal_history_per_instance[graph_name][exp_hash]
+        step_i = int(global_step)
+        idx_map = self._instance_index.setdefault(graph_name, {}).setdefault(exp_hash, {})
+        try:
+            import numpy as _np
+            vals = _np.asarray(values, dtype=_np.float32).ravel()
+        except Exception:
+            vals = [float(v) for v in values]
+
+        for sid, aid, val in zip(sample_ids, annotation_ids, vals):
+            row = len(buf["sample_ids"])
+            sid_s, aid_i = str(sid), int(aid)
+            buf["sample_ids"].append(sid_s)
+            buf["annotation_ids"].append(aid_i)
+            buf["steps"].append(step_i)
+            buf["values"].append(float(val))
+            idx_map.setdefault((sid_s, aid_i), []).append(row)
+
+    def get_signal_history_per_instance(self) -> dict:
+        """Reconstruct per-instance history as list-of-dicts from compact array storage."""
+        result = {}
+        for graph_name, exps in self._signal_history_per_instance.items():
+            result[graph_name] = {}
+            for exp_hash, buf in exps.items():
+                entries = []
+                for sid, aid, step, val in zip(
+                    buf["sample_ids"], buf["annotation_ids"], buf["steps"], buf["values"]
+                ):
+                    entries.append({
+                        "sample_id":       str(sid),
+                        "annotation_id":   int(aid),
+                        "model_age":       int(step),
+                        "metric_name":     graph_name,
+                        "metric_value":    float(val),
+                        "experiment_hash": exp_hash,
+                    })
+                result[graph_name][exp_hash] = entries
+        return result
 
     def save_snapshot(self) -> dict:
         """Build a serializable snapshot of the logger state."""
         self._flush_current_step_buffer(add_to_queue=False)
 
-        # Compact serialization: store 3 parallel lists instead of list-of-dicts
+        # Compact serialization: store parallel lists instead of list-of-dicts
         per_sample_compact = {}
         for graph_name, exps in self._signal_history_per_sample.items():
             per_sample_compact[graph_name] = {}
@@ -575,10 +811,23 @@ class LoggerQueue:
                     "values":     list(buf["values"]),
                 }
 
+        per_instance_compact = {}
+        for graph_name, exps in self._signal_history_per_instance.items():
+            per_instance_compact[graph_name] = {}
+            for exp_hash, buf in exps.items():
+                per_instance_compact[graph_name][exp_hash] = {
+                    "_compact":       True,
+                    "sample_ids":     list(buf["sample_ids"]),
+                    "annotation_ids": list(buf["annotation_ids"]),
+                    "steps":          list(buf["steps"]),
+                    "values":         list(buf["values"]),
+                }
+
         return {
             "graph_names": sorted(self.graph_names),
             "signal_history": self.get_signal_history(),
             "signal_history_per_sample": per_sample_compact,
+            "signal_history_per_instance": per_instance_compact,
         }
 
     # ------------------------------------------------------------------
@@ -737,11 +986,15 @@ class LoggerQueue:
                     ids   = entries.get("sample_ids", [])
                     steps = entries.get("steps", [])
                     vals  = entries.get("values", [])
+                    idx_map = self._sample_index.setdefault(metric_name, {}).setdefault(exp_hash, {})
                     for s, t, v in zip(ids, steps, vals):
                         try:
-                            buf["sample_ids"].append(int(s))
+                            row = len(buf["sample_ids"])
+                            sid_s = str(s)
+                            buf["sample_ids"].append(sid_s)
                             buf["steps"].append(int(t))
                             buf["values"].append(float(v))
+                            idx_map.setdefault(sid_s, []).append(row)
                         except (TypeError, ValueError):
                             pass
 
@@ -750,13 +1003,17 @@ class LoggerQueue:
                     if exp_hash not in self._signal_history_per_sample[metric_name]:
                         self._signal_history_per_sample[metric_name][exp_hash] = _make_per_sample_buf()
                     buf = self._signal_history_per_sample[metric_name][exp_hash]
+                    idx_map = self._sample_index.setdefault(metric_name, {}).setdefault(exp_hash, {})
                     for entry in entries:
                         if not isinstance(entry, dict):
                             continue
                         try:
-                            buf["sample_ids"].append(int(entry.get("sample_id", -1)))
+                            row = len(buf["sample_ids"])
+                            sid_s = str(entry.get("sample_id", -1))
+                            buf["sample_ids"].append(sid_s)
                             buf["steps"].append(int(entry.get("model_age", 0)))
                             buf["values"].append(float(entry.get("metric_value", 0.0)))
+                            idx_map.setdefault(sid_s, []).append(row)
                         except (TypeError, ValueError):
                             pass
 
@@ -766,11 +1023,47 @@ class LoggerQueue:
                     if null_key not in self._signal_history_per_sample[metric_name]:
                         self._signal_history_per_sample[metric_name][null_key] = _make_per_sample_buf()
                     buf = self._signal_history_per_sample[metric_name][null_key]
+                    idx_map = self._sample_index.setdefault(metric_name, {}).setdefault(null_key, {})
                     try:
-                        sid = str(exp_hash) if isinstance(exp_hash, (int, float)) else -1
+                        row = len(buf["sample_ids"])
+                        sid = str(exp_hash) if isinstance(exp_hash, (int, float)) else str(-1)
                         buf["sample_ids"].append(sid)
                         buf["steps"].append(int(entries.get("model_age", 0)))
                         buf["values"].append(float(entries.get("metric_value", 0.0)))
+                        idx_map.setdefault(sid, []).append(row)
+                    except (TypeError, ValueError):
+                        pass
+
+    def load_signal_history_per_instance(self, signals_per_instance: dict) -> None:
+        """Load per-instance history from a compact snapshot dict."""
+        if not signals_per_instance:
+            return
+        for metric_name, exps in signals_per_instance.items():
+            self.graph_names.add(metric_name)
+            if metric_name not in self._signal_history_per_instance:
+                self._signal_history_per_instance[metric_name] = {}
+            if not isinstance(exps, dict):
+                continue
+            for exp_hash, entries in exps.items():
+                if not (isinstance(entries, dict) and entries.get("_compact")):
+                    continue
+                if exp_hash not in self._signal_history_per_instance[metric_name]:
+                    self._signal_history_per_instance[metric_name][exp_hash] = _make_per_instance_buf()
+                buf  = self._signal_history_per_instance[metric_name][exp_hash]
+                ids  = entries.get("sample_ids", [])
+                aids = entries.get("annotation_ids", [])
+                steps = entries.get("steps", [])
+                vals  = entries.get("values", [])
+                idx_map = self._instance_index.setdefault(metric_name, {}).setdefault(exp_hash, {})
+                for s, a, t, v in zip(ids, aids, steps, vals):
+                    try:
+                        row = len(buf["sample_ids"])
+                        sid_s, aid_i = str(s), int(a)
+                        buf["sample_ids"].append(sid_s)
+                        buf["annotation_ids"].append(aid_i)
+                        buf["steps"].append(int(t))
+                        buf["values"].append(float(v))
+                        idx_map.setdefault((sid_s, aid_i), []).append(row)
                     except (TypeError, ValueError):
                         pass
 
@@ -779,14 +1072,14 @@ class LoggerQueue:
         if not snapshot:
             return
 
-        # Load graph names if available in snapshot (added in later versions)
         graph_names = snapshot.get("graph_names", [])
         self.graph_names.update(graph_names)
 
-        # Load signal history if available in snapshot (added in later versions)
         signals = snapshot.get("signal_history", [])
         self.load_signal_history(signals)
 
-        # Load per-sample signals if available in snapshot (added in later versions)
         signals_per_sample = snapshot.get("signal_history_per_sample", {})
         self.load_signal_history_per_sample(signals_per_sample)
+
+        signals_per_instance = snapshot.get("signal_history_per_instance", {})
+        self.load_signal_history_per_instance(signals_per_instance)

--- a/weightslab/components/checkpoint_manager.py
+++ b/weightslab/components/checkpoint_manager.py
@@ -53,7 +53,7 @@ from weightslab.backend.ledgers import (
     get_dataloaders,
 )
 from weightslab.backend import ledgers
-from weightslab.utils.logger import LoggerQueue
+from weightslab.backend.logger import LoggerQueue
 from weightslab.data.sample_stats import SampleStatsEx
 from weightslab.utils.tools import capture_rng_state, restore_rng_state, recursive_update, normalize_config, safe_reset_index
 from weightslab.components.global_monitoring import pause_controller as pause_ctrl

--- a/weightslab/examples/PyTorch/ws-detection/src/config.yaml
+++ b/weightslab/examples/PyTorch/ws-detection/src/config.yaml
@@ -38,7 +38,8 @@ ledger_flush_interval: 60.0
 # Data
 num_classes: 2
 image_size: 320
-data_root: ./data/data.yaml  # Uncomment and set the path to your data.yaml file.
+# data_root: ./data/data.yaml  # Uncomment and set the path to your data.yaml file.
+data_root: C:\Users\GuillaumePELLUET\Documents\Codes\weightslab_kitchen\guillaume_playground\ws-detection\data\data.yaml
 data:
   train_loader:
     batch_size: 4

--- a/weightslab/examples/PyTorch/ws-detection/src/main.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/main.py
@@ -127,6 +127,7 @@ def main():
     # 7. Training Loop
     wl.start_training(timeout=None)  # This will block and keep the main thread alive while background services run. You can optionally set a timeout (in seconds) to automatically stop after a certain duration.
     trainer.train()
+
     wl.keep_serving()
 
 

--- a/weightslab/examples/PyTorch/ws-detection/src/main.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/main.py
@@ -19,167 +19,17 @@ import yaml
 
 import weightslab as wl
 
-from weightslab.utils.logger import LoggerQueue
+from weightslab.backend.logger import LoggerQueue
 
 from ultralytics.data.dataset import YOLODataset
-from ultralytics.models.yolo.detect import DetectionTrainer
 from ultralytics.cfg import get_cfg
 from ultralytics.data.utils import check_det_dataset
 
+from utils.trainer import WLCompatileDetTrainer
 from utils.data import YOLODatasetWL, _wl_yolo_collate as collate_fn
-from utils.criterions import (
-    PerSampleDetectionLoss, PerSampleIoU,
-    PerInstanceDetectionLoss, PerInstanceIoU,
-    _decode_predictions
-)
 
 logging.getLogger("weightslab.watchdog.grpc_watchdog").setLevel(logging.ERROR)
 logging.getLogger("weightslab.trainer.services.agent.agent").setLevel(logging.ERROR)
-
-
-# ==================
-# Trainer Definition
-# ==================
-
-class WLCompatileDetTrainer(DetectionTrainer):
-    def __init__(self, *a, **kw):
-        self.data_train_loader = kw.pop("train_loader")
-        self.data_val_loader = kw.pop("val_loader")
-        self.hparams = kw.pop("hparams", {})
-        self.device = kw.get("device", torch.device("cpu"))
-        super().__init__(*a, **kw)
-        self._init_experiment_modules()
-
-    @property
-    def val_every(self):
-        return self.hparams.get("eval_full_to_train_steps_ratio", 1)
-
-    def _init_experiment_modules(self):
-        super().setup_model()
-        self.model = self.model.to(self.device)
-
-        # Order matters: _setup_train builds the optimizer, which iterates model.modules()
-        # with isinstance checks that fail once WL wraps the model. Run it BEFORE wrapping.
-        self._init_training_loss()
-        self._setup_train()
-        self.optimizer = wl.watch_or_edit(self.optimizer, flag="optimizer")
-        self.model = wl.watch_or_edit(
-            self.model, flag="model", device=self.device, compute_dependencies=False)
-
-    def _init_training_loss(self):
-        if not hasattr(self.model, "args"):
-            self.model.args = get_cfg()
-        _LOSS_PARTS = [(0, "bbxs"), (1, "clsf"), (2, "dfl")]
-        self.criterions = {"train": {}, "val": {}}
-        self.criterions_per_instance = {"train": {}, "val": {}}
-        self.iou = {}
-        self.iou_per_instance = {}
-        for split in ("train", "val"):
-            # Per-sample metrics (aggregated)
-            for t, n in _LOSS_PARTS:
-                self.criterions[split][n] = wl.watch_or_edit(
-                    PerSampleDetectionLoss(self.model, loss_type=t),
-                    flag="loss", name=f"{split}/{n}_sample", per_sample=True, log=True,
-                )
-            self.iou[split] = wl.watch_or_edit(
-                PerSampleIoU(conf=0.25, iou_thres=0.5),
-                flag="metric", name=f"iou/{split}_sample", per_sample=True, log=True,
-            )
-
-            # Per-instance metrics (per annotation) — auto-saved by WL with annotation_id
-            for t, n in _LOSS_PARTS:
-                self.criterions_per_instance[split][n] = wl.watch_or_edit(
-                    PerInstanceDetectionLoss(self.model, loss_type=t),
-                    flag="loss", name=f"{split}/{n}_instance", per_instance=True, log=True,
-                )
-            self.iou_per_instance[split] = wl.watch_or_edit(
-                PerInstanceIoU(conf=0.25, iou_thres=0.5),
-                flag="metric", name=f"iou/{split}_instance", per_instance=True, log=True,
-            )
-
-    def process_predictions(self, pred_raw, image, conf=0.25, cls_thresh=0.5):
-        img_h, img_w = image[0].shape[-2:]
-
-        # Process check for eval mode
-        if isinstance(pred_raw, (tuple, list)):
-            pred_raw = pred_raw[1]
-
-        # Gen. bounding boxes
-        pred_raw = torch.cat([pred_raw['boxes'], pred_raw['scores']], dim=1)
-        # Convert to raw model predictions format [batch, 64+nc, 8400]
-        preds_bboxes, preds_cls = _decode_predictions(
-            pred_raw, img_h, img_w, conf=conf, iou_thres=cls_thresh)
-
-        return preds_bboxes, preds_cls
-
-    def train(self):
-        cs, m = self.criterions["train"], self.iou["train"]
-        cs_inst, m_inst = self.criterions_per_instance["train"], self.iou_per_instance["train"]
-
-        while True:
-            with wl.guard_training_context:
-                self.optimizer.zero_grad()
-                inputs = next(self.data_train_loader)
-                image, batch_ids, batch = inputs[0].float(), inputs[1], inputs[3]['batch']
-
-                raw_preds = self.model(image.to(self.device))
-                if not isinstance(raw_preds, dict):
-                    raw_preds = raw_preds[1]  # For audit mode, we are in evaluation so model also output the bb
-                preds_bboxes, preds_cls = self.process_predictions(raw_preds, image, conf=0.0001, cls_thresh=0.0001)
-                imgsz = float(image.shape[-1])
-                preds_by_batch = [
-                    torch.cat([b.detach().cpu() / imgsz, c[:, 1:2].cpu(), c[:, 0:1].cpu()], dim=-1)
-                    if b.numel() > 0 else torch.zeros((0, 6))
-                    for b, c in zip(preds_bboxes, preds_cls)
-                ]
-
-                # Per-sample signals — used for backward pass
-                per_sample = (
-                    cs["bbxs"](raw_preds, batch, batch_ids=batch_ids, preds={'bboxes': preds_by_batch})
-                    + cs["clsf"](raw_preds, batch, batch_ids=batch_ids)
-                    + cs["dfl"](raw_preds, batch, batch_ids=batch_ids)
-                )
-                m(raw_preds, batch, batch_ids=batch_ids)
-
-                # Per-instance signals (per annotation) — auto-saved with annotation_id
-                cs_inst["bbxs"](raw_preds, batch, batch_ids=batch_ids)
-                cs_inst["clsf"](raw_preds, batch, batch_ids=batch_ids)
-                cs_inst["dfl"](raw_preds, batch, batch_ids=batch_ids)
-                m_inst(raw_preds, batch, batch_ids=batch_ids)
-
-                loss = per_sample.mean()
-                loss.backward()
-                self.optimizer.step()
-
-            if self.model.get_age() % self.val_every == 0:
-                with wl.guard_testing_context:
-                    self.do_validate(self.data_val_loader)
-
-    def do_validate(self, loader):
-        cs, m = self.criterions["val"], self.iou["val"]
-        cs_inst, m_inst = self.criterions_per_instance["val"], self.iou_per_instance["val"]
-        for inputs in loader:
-            image, batch_ids, batch = inputs[0].float(), inputs[1], inputs[3]['batch']
-            raw_preds = self.model(image.to(self.device))[1]
-            preds_bboxes, preds_cls = self.process_predictions(raw_preds, image, conf=0.0001, cls_thresh=0.0001)
-            imgsz = float(image.shape[-1])
-            preds_by_batch = [
-                torch.cat([b.detach().cpu() / imgsz, c[:, 1:2].cpu(), c[:, 0:1].cpu()], dim=-1)
-                if b.numel() > 0 else torch.zeros((0, 6))
-                for b, c in zip(preds_bboxes, preds_cls)
-            ]
-
-            # Per-sample metrics (aggregated per sample)
-            cs["bbxs"](raw_preds, batch, batch_ids=batch_ids, preds={'bboxes': preds_by_batch})
-            cs["clsf"](raw_preds, batch, batch_ids=batch_ids)
-            cs["dfl"](raw_preds, batch, batch_ids=batch_ids)
-            m(raw_preds, batch, batch_ids=batch_ids)
-
-            # Per-instance metrics (per annotation) — auto-saved with annotation_id
-            cs_inst["bbxs"](raw_preds, batch, batch_ids=batch_ids, preds={'bboxes': preds_by_batch})
-            cs_inst["clsf"](raw_preds, batch, batch_ids=batch_ids)
-            cs_inst["dfl"](raw_preds, batch, batch_ids=batch_ids)
-            m_inst(raw_preds, batch, batch_ids=batch_ids)
 
 
 def main():
@@ -268,6 +118,7 @@ def main():
         hparams=parameters,
     )
 
+    # Wrap the custom function to be able to use WeightsStudio Evaluation Feature
     @wl.eval_fn
     def _wl_validate(loader):
         trainer.do_validate(loader)

--- a/weightslab/examples/PyTorch/ws-detection/src/utils/criterions.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/utils/criterions.py
@@ -1,11 +1,16 @@
+import numpy as np
 import torch as th
 import torch.nn as nn
+import weightslab as wl
 
 from ultralytics.utils.loss import v8DetectionLoss as DetectionLoss
 from ultralytics.utils.nms import non_max_suppression
 from ultralytics.utils.tal import make_anchors, dist2bbox
 from ultralytics.utils.nms import box_iou
 from ultralytics.utils.ops import xywh2xyxy
+
+from weightslab.backend import ledgers
+
 
 def _decode_predictions(pred, img_h, img_w, conf=0.25, iou_thres=0.5):
     """Decode raw model preds [batch, 64+nc, 8400] → per-sample (boxes, [score, cls]) after NMS."""
@@ -274,3 +279,112 @@ class PerInstanceDetectionLoss(nn.Module):
         if not instance_losses:
             return th.tensor([], device=device)
         return th.stack(instance_losses)
+
+
+# =========================================================================
+# Custom subscribed signal: per-sample loss-shape classification
+# =========================================================================
+# This is a *dynamic* WeightsLab signal. It subscribes to the per-sample
+# classification loss "train/clsf_sample" and, every 25 optimisation steps,
+# inspects each sample's full loss trajectory, classifies its *shape*, and
+# writes the verdict back onto the sample as the categorical tag "loss_shape".
+#
+# The six shapes describe how a sample's loss evolved over training:
+#   monotonic     -> loss steadily decreasing             (model is learning it)
+#   plateaued     -> dropped then leveled off still-high  (stuck / hard sample)
+#   Flat_high     -> never moved, stayed high             (mislabel / unlearnable)
+#   high_variance -> noisy oscillation                    (ambiguous label)
+#   U_Shape       -> learned then forgotten               (catastrophic interference)
+#   Spiked        -> sudden jump at some step             (data/aug/version change)
+
+# Allowed values for the categorical tag, in display order.
+LOSS_SHAPE_LABELS = [
+    "monotonic", "plateaued", "Flat_high",
+    "high_variance", "U_Shape", "Spiked",
+]
+
+# Numeric encoding returned by the signal so the verdict is also plottable
+# per-sample (a tag is a string; a signal must be numeric).
+LOSS_SHAPE_CODES = {label: i for i, label in enumerate(LOSS_SHAPE_LABELS)}
+
+# Minimum number of logged points before a trajectory can be classified.
+_MIN_HISTORY = 5
+
+# Get checkpoint manager
+checkpoint_manager = ledgers.get_checkpoint_manager()
+
+# Declare the categorical tag written by the loss-shape classifier signal,
+# so the UI shows all six choices even before any sample is tagged. Must be
+# called after the dataloader is registered (the dataframe now exists).
+wl.register_categorical_tag("loss_shape", LOSS_SHAPE_LABELS)
+
+
+def _classify_loss_shape(values):
+    """Classify a per-sample loss trajectory into one of LOSS_SHAPE_LABELS.
+
+    *values* is the loss series ordered by step. Returns a label string, or
+    ``None`` when there is not enough history yet to decide. All thresholds
+    are scale-invariant (expressed as fractions of the trajectory's own
+    range), so the same logic works regardless of the absolute loss scale.
+    These thresholds are illustrative — tune them for your own task.
+    """
+    y = np.asarray(values, dtype=float)
+    if y.size < _MIN_HISTORY:
+        return None
+
+    n = y.size
+    first, last = float(y[0]), float(y[-1])
+    ymin, ymax = float(y.min()), float(y.max())
+    rng = max(ymax - ymin, 1e-8)
+    mean = float(y.mean())
+
+    cv = float(y.std()) / (abs(mean) + 1e-8)        # noisiness (coeff. of variation)
+    drop = (first - last) / (abs(first) + 1e-8)     # net improvement, start -> end
+    argmin = int(np.argmin(y))
+    rebound = (last - ymin) / rng                    # how far it climbed back from the trough
+    max_up_jump = float(np.diff(y).max()) / rng      # largest single-step rise
+
+    # Flat, recent tail (last 40% of the trajectory) is used to detect plateaus.
+    tail = y[int(0.6 * n):]
+    tail_flat = (float(tail.std()) / (abs(float(tail.mean())) + 1e-8)) < 0.1
+
+    # Order matters: most specific / most alarming shapes are checked first.
+    if max_up_jump > 0.5:                            # one big isolated jump up
+        return "Spiked"
+    if cv > 0.5:                                     # globally noisy / oscillating
+        return "high_variance"
+    if 0.2 * n < argmin < 0.8 * n and rebound > 0.3:  # dipped mid-run, then rose
+        return "U_Shape"
+    if drop > 0.4:                                   # large, steady net decrease
+        return "monotonic"
+    if drop > 0.15 and tail_flat:                    # modest drop, then leveled high
+        return "plateaued"
+    return "Flat_high"                               # barely moved — never learned
+
+
+@wl.signal(
+    name="loss_shape_classifier",
+    subscribe_to="train/clsf_sample",
+    compute_every_n_steps=25,
+    log=False,  # side-effecting signal: we tag samples, no aggregate curve needed
+)
+def classify_loss_shape(ctx: wl.SignalContext) -> int:
+    """Dynamic signal fired per sample every 25 steps for "train/clsf_sample".
+
+    Pulls the sample's full loss history, classifies its shape, and tags the
+    sample with the categorical tag ``loss_shape``. Returns the numeric shape
+    code (or -1 when there is not enough history yet) so the verdict is also
+    available as a per-sample signal column.
+    """
+    # Full per-sample trajectory of the subscribed metric, ordered by step.
+    history = wl.query_sample_history(ctx.sample_id, signal_name="train/clsf_sample", exp_hash=checkpoint_manager.get_current_experiment_hash())
+    series = sorted(((step, val) for _, step, val, _ in history), key=lambda t: t[0])
+    values = [v for _, v in series]
+
+    label = _classify_loss_shape(values)
+    if label is None:
+        return -1
+
+    # Persist the verdict as a categorical tag on this sample.
+    wl.set_categorical_tag([ctx.sample_id], "loss_shape", label)
+    return LOSS_SHAPE_CODES[label]

--- a/weightslab/examples/PyTorch/ws-detection/src/utils/trainer.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/utils/trainer.py
@@ -1,0 +1,196 @@
+import os
+os.environ.setdefault("WL_PRELOAD_IMAGE_OVERVIEW", "0")
+os.environ.setdefault("WEIGHTSLAB_LOG_LEVEL", "WARNING")
+
+import warnings
+from tables import NaturalNameWarning
+warnings.filterwarnings("ignore", category=NaturalNameWarning)
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    message="Setting an item of incompatible dtype is deprecated.*",
+)
+
+import logging
+import tempfile
+import numpy as np
+import torch
+import yaml
+
+import weightslab as wl
+
+from weightslab.backend.logger import LoggerQueue
+
+from ultralytics.data.dataset import YOLODataset
+from ultralytics.models.yolo.detect import DetectionTrainer
+from ultralytics.cfg import get_cfg
+from ultralytics.data.utils import check_det_dataset
+
+from utils.data import YOLODatasetWL, _wl_yolo_collate as collate_fn
+from utils.criterions import (
+    PerSampleDetectionLoss, PerSampleIoU,
+    PerInstanceDetectionLoss, PerInstanceIoU,
+    _decode_predictions
+)
+
+logging.getLogger("weightslab.watchdog.grpc_watchdog").setLevel(logging.ERROR)
+logging.getLogger("weightslab.trainer.services.agent.agent").setLevel(logging.ERROR)
+
+
+# ==================
+# Trainer Definition
+# ==================
+
+class WLCompatileDetTrainer(DetectionTrainer):
+    def __init__(self, *a, **kw):
+        self.data_train_loader = kw.pop("train_loader")
+        self.data_val_loader = kw.pop("val_loader")
+        self.hparams = kw.pop("hparams", {})
+        self.device = kw.get("device", torch.device("cpu"))
+        super().__init__(*a, **kw)
+        self._init_experiment_modules()
+
+    @property
+    def val_every(self):
+        return self.hparams.get("eval_full_to_train_steps_ratio", 1)
+
+    def _init_experiment_modules(self):
+        super().setup_model()
+        self.model = self.model.to(self.device)
+
+        # Order matters: _setup_train builds the optimizer, which iterates model.modules()
+        # with isinstance checks that fail once WL wraps the model. Run it BEFORE wrapping.
+        self._init_training_loss()
+        self._setup_train()
+        self.optimizer = wl.watch_or_edit(self.optimizer, flag="optimizer")
+        self.model = wl.watch_or_edit(
+            self.model, flag="model", device=self.device, compute_dependencies=False)
+
+    def _init_training_loss(self):
+        if not hasattr(self.model, "args"):
+            self.model.args = get_cfg()
+        _LOSS_PARTS = [(0, "bbxs"), (1, "clsf"), (2, "dfl")]
+        self.criterions = {"train": {}, "val": {}}
+        self.criterions_per_instance = {"train": {}, "val": {}}
+        self.iou = {}
+        self.iou_per_instance = {}
+        for split in ("train", "val"):
+            # Per-sample metrics (aggregated)
+            for t, n in _LOSS_PARTS:
+                self.criterions[split][n] = wl.watch_or_edit(
+                    PerSampleDetectionLoss(self.model, loss_type=t),
+                    flag="loss", name=f"{split}/{n}_sample", per_sample=True, log=True,
+                )
+            self.iou[split] = wl.watch_or_edit(
+                PerSampleIoU(conf=0.25, iou_thres=0.5),
+                flag="metric", name=f"iou/{split}_sample", per_sample=True, log=True,
+            )
+
+            # Per-instance metrics (per annotation) — auto-saved by WL with annotation_id
+            for t, n in _LOSS_PARTS:
+                self.criterions_per_instance[split][n] = wl.watch_or_edit(
+                    PerInstanceDetectionLoss(self.model, loss_type=t),
+                    flag="loss", name=f"{split}/{n}_instance", per_instance=True, log=True,
+                )
+            self.iou_per_instance[split] = wl.watch_or_edit(
+                PerInstanceIoU(conf=0.25, iou_thres=0.5),
+                flag="metric", name=f"iou/{split}_instance", per_instance=True, log=True,
+            )
+
+    def process_predictions(self, pred_raw, image, conf=0.25, cls_thresh=0.5):
+        img_h, img_w = image[0].shape[-2:]
+
+        # Process check for eval mode
+        if isinstance(pred_raw, (tuple, list)):
+            pred_raw = pred_raw[1]
+
+        # Gen. bounding boxes
+        pred_raw = torch.cat([pred_raw['boxes'], pred_raw['scores']], dim=1)
+        # Convert to raw model predictions format [batch, 64+nc, 8400]
+        preds_bboxes, preds_cls = _decode_predictions(
+            pred_raw, img_h, img_w, conf=conf, iou_thres=cls_thresh)
+
+        return preds_bboxes, preds_cls
+
+    def train(self):
+        cs, m = self.criterions["train"], self.iou["train"]
+        cs_inst, m_inst = self.criterions_per_instance["train"], self.iou_per_instance["train"]
+
+        while True:
+            with wl.guard_training_context:
+                self.optimizer.zero_grad()
+                inputs = next(self.data_train_loader)
+                image, batch_ids, batch = inputs[0].float(), inputs[1], inputs[3]['batch']
+
+                raw_preds = self.model(image.to(self.device))
+                if not isinstance(raw_preds, dict):
+                    raw_preds = raw_preds[1]  # For audit mode, we are in evaluation so model also output the bb
+                preds_bboxes, preds_cls = self.process_predictions(raw_preds, image, conf=0.0001, cls_thresh=0.0001)
+                imgsz = float(image.shape[-1])
+                preds_by_batch = [
+                    torch.cat([b.detach().cpu() / imgsz, c[:, 1:2].cpu(), c[:, 0:1].cpu()], dim=-1)
+                    if b.numel() > 0 else torch.zeros((0, 6))
+                    for b, c in zip(preds_bboxes, preds_cls)
+                ]
+
+                # Per-sample signals — used for backward pass
+                per_sample = (
+                    cs["bbxs"](raw_preds, batch, batch_ids=batch_ids, preds={'bboxes': preds_by_batch})
+                    + cs["clsf"](raw_preds, batch, batch_ids=batch_ids)
+                    + cs["dfl"](raw_preds, batch, batch_ids=batch_ids)
+                )
+                m(raw_preds, batch, batch_ids=batch_ids)
+
+                # Per-instance signals (per annotation) — auto-saved with annotation_id
+                cs_inst["bbxs"](raw_preds, batch, batch_ids=batch_ids)
+                cs_inst["clsf"](raw_preds, batch, batch_ids=batch_ids)
+                cs_inst["dfl"](raw_preds, batch, batch_ids=batch_ids)
+                m_inst(raw_preds, batch, batch_ids=batch_ids)
+
+                loss = per_sample.mean()
+                loss.backward()
+                self.optimizer.step()
+
+            if self.model.get_age() % self.val_every == 0:
+                with wl.guard_testing_context:
+                    self.do_validate(self.data_val_loader)
+
+            # Write the history of these samples every x steps
+            if self.model.get_age() % 100 == 0:
+                wl.write_history(
+                    # path=None,  # Use root_log_dir by default, filename generated from parameters md5 hash
+                    type_of_history="instance",
+                    graph_name=[
+                        'train/clsf_instance',
+                        'val/clsf_instance'
+                    ],
+                    # experiment_hash=None,  Default is 'last', i.e., current experiment hash
+                    sample_id=['11', '29', '28', '27', '22'],
+                    instance_id=[1, 2, 3]
+                )
+
+    def do_validate(self, loader):
+        cs, m = self.criterions["val"], self.iou["val"]
+        cs_inst, m_inst = self.criterions_per_instance["val"], self.iou_per_instance["val"]
+        for inputs in loader:
+            image, batch_ids, batch = inputs[0].float(), inputs[1], inputs[3]['batch']
+            raw_preds = self.model(image.to(self.device))[1]
+            preds_bboxes, preds_cls = self.process_predictions(raw_preds, image, conf=0.0001, cls_thresh=0.0001)
+            imgsz = float(image.shape[-1])
+            preds_by_batch = [
+                torch.cat([b.detach().cpu() / imgsz, c[:, 1:2].cpu(), c[:, 0:1].cpu()], dim=-1)
+                if b.numel() > 0 else torch.zeros((0, 6))
+                for b, c in zip(preds_bboxes, preds_cls)
+            ]
+
+            # Per-sample metrics (aggregated per sample)
+            cs["bbxs"](raw_preds, batch, batch_ids=batch_ids, preds={'bboxes': preds_by_batch})
+            cs["clsf"](raw_preds, batch, batch_ids=batch_ids)
+            cs["dfl"](raw_preds, batch, batch_ids=batch_ids)
+            m(raw_preds, batch, batch_ids=batch_ids)
+
+            # Per-instance metrics (per annotation) — auto-saved with annotation_id
+            cs_inst["bbxs"](raw_preds, batch, batch_ids=batch_ids, preds={'bboxes': preds_by_batch})
+            cs_inst["clsf"](raw_preds, batch, batch_ids=batch_ids)
+            cs_inst["dfl"](raw_preds, batch, batch_ids=batch_ids)
+            m_inst(raw_preds, batch, batch_ids=batch_ids)

--- a/weightslab/examples/PyTorch/ws-detection/src/utils/trainer.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/utils/trainer.py
@@ -12,21 +12,13 @@ warnings.filterwarnings(
 )
 
 import logging
-import tempfile
-import numpy as np
 import torch
-import yaml
 
 import weightslab as wl
 
-from weightslab.backend.logger import LoggerQueue
-
-from ultralytics.data.dataset import YOLODataset
 from ultralytics.models.yolo.detect import DetectionTrainer
 from ultralytics.cfg import get_cfg
-from ultralytics.data.utils import check_det_dataset
 
-from utils.data import YOLODatasetWL, _wl_yolo_collate as collate_fn
 from utils.criterions import (
     PerSampleDetectionLoss, PerSampleIoU,
     PerInstanceDetectionLoss, PerInstanceIoU,

--- a/weightslab/examples/PyTorch/ws-detection/src/utils/trainer.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/utils/trainer.py
@@ -168,6 +168,13 @@ class WLCompatileDetTrainer(DetectionTrainer):
                     sample_id=['11', '29', '28', '27', '22'],
                     instance_id=[1, 2, 3]
                 )
+                # Dump the sample dataframe: all signals plus the loss_shape categorical tag,
+                wl.write_dataframe(
+                    columns=["signals", "tag:loss_shape"],
+                    format='csv'
+                    # sample_id=['0', '28']
+                    # instance_id=[1, 2],
+                )
 
     def do_validate(self, loader):
         cs, m = self.criterions["val"], self.iou["val"]

--- a/weightslab/examples/PyTorch/ws-detection/src/yolo_pipeline.py
+++ b/weightslab/examples/PyTorch/ws-detection/src/yolo_pipeline.py
@@ -37,7 +37,7 @@ def _build_pipeline(cfg, device, rank, world_size):
     Returns (trainer, train_loader, criterions, my_uids, all_uids).
     """
     import weightslab as wl
-    from weightslab.utils.logger import LoggerQueue
+    from weightslab.backend.logger import LoggerQueue
     from ultralytics.data.dataset import YOLODataset
     from ultralytics.models.yolo.detect import DetectionTrainer
     from ultralytics.cfg import get_cfg

--- a/weightslab/examples/PyTorch/ws-segmentation/main.py
+++ b/weightslab/examples/PyTorch/ws-segmentation/main.py
@@ -13,7 +13,7 @@ import weightslab as wl
 from torch import optim
 
 
-from weightslab.utils.logger import LoggerQueue
+from weightslab.backend.logger import LoggerQueue
 from weightslab.components.global_monitoring import (
     guard_training_context,
     guard_testing_context,

--- a/weightslab/src.py
+++ b/weightslab/src.py
@@ -3438,6 +3438,246 @@ def write_history(
     return path
 
 
+def write_dataframe(
+    path: str | None = None,
+    format: str = "json",
+    columns=None,
+    sample_id=None,
+    instance_id=None,
+) -> str:
+    """Dump the WeightsLab sample dataframe to *path* as JSON or CSV.
+
+    Parameters
+    ----------
+    path : str, optional
+        Output file path **or** directory.  When omitted (``None``), the
+        ``root_log_dir`` from the active checkpoint manager is used.
+
+        - If *path* has a file extension the file is written directly.
+        - If *path* has no extension or is an existing directory, a filename is
+          auto-generated as ``<hash>_dataframe.<format>`` inside that directory.
+          ``<hash>`` is an 8-character MD5 hex digest of the normalized call
+          parameters (*columns*, *sample_id*, *instance_id*).  Same filters →
+          same filename (idempotent overwrite); different filters → different
+          file.
+        - The directory is created automatically if it does not exist.
+    format : {"json", "csv"}
+        Output format.  Default ``"json"``.
+    columns : str or list of str, optional
+        Which columns to include (index levels ``sample_id`` / ``annotation_id``
+        are always written).
+
+        - ``None`` / ``"all"`` — every column.
+        - ``"tags"`` — only columns prefixed with ``tag:`` (categorical and
+          boolean tags, e.g. ``tag:loss_shape``, ``tag:weather``).
+        - ``"signals"`` — only columns prefixed with ``signals`` (per-sample
+          signals logged by ``wl.watch_or_edit`` or ``wl.save_signals``).
+        - ``"discarded"`` — only the boolean ``discarded`` column.
+        - A list of any mix of the above group names and/or exact column names.
+    sample_id : str or list of str, optional
+        Restrict to one or more sample IDs (index level 0).  ``None`` keeps all.
+    instance_id : int or list of int, optional
+        Restrict to one or more annotation IDs (index level 1, 0 = sample row,
+        ≥ 1 = per-instance rows).  ``None`` keeps all.
+
+    Returns
+    -------
+    str
+        Absolute path of the file that was written.
+
+    Notes
+    -----
+    The function calls ``flush()`` on the dataframe manager before reading so
+    that any in-flight writes are included in the output.  Pass
+    ``instance_id=0`` to keep only sample-level rows; pass ``instance_id=[1,2]``
+    to keep specific annotation rows.
+
+    Examples
+    --------
+    Dump everything (path inferred from ``root_log_dir``)::
+
+        wl.write_dataframe()
+
+    Dump only tags to CSV::
+
+        wl.write_dataframe("tags.csv", format="csv", columns="tags")
+
+    Dump signals + discarded for specific samples::
+
+        wl.write_dataframe(
+            "subset.json",
+            columns=["signals", "discarded"],
+            sample_id=["img_001", "img_042"],
+        )
+    """
+    import csv as _csv
+    import json as _json
+    import os as _os
+    import hashlib as _hashlib
+
+    logger.debug(
+        "write_dataframe called: path=%r, format=%r, columns=%r, "
+        "sample_id=%r, instance_id=%r",
+        path, format, columns, sample_id, instance_id,
+    )
+
+    _dm = get_dataframe()
+    if _dm is None:
+        logger.warning(
+            "write_dataframe: no active dataframe manager; nothing to write. "
+            "Returning path=%r.", path or "."
+        )
+        return path or "."
+
+    # Resolve path: fall back to root_log_dir from the checkpoint manager
+    if path is None:
+        _lg = get_logger()
+        try:
+            _cm = _lg.chkpt_manager if _lg is not None else None
+            _rld = _cm.root_log_dir if _cm is not None else None
+            path = str(_rld) if _rld is not None else "."
+        except Exception as _e:
+            logger.debug("write_dataframe: failed to resolve root_log_dir (%s); "
+                         "falling back to current directory.", _e)
+            path = "."
+        logger.info("write_dataframe: no path given, using output directory %r.", path)
+
+    fmt = format.lower().strip()
+
+    # Normalize sample_id → list[str] or None
+    _sid_filter = None
+    if sample_id is not None:
+        _sid_filter = [str(sample_id)] if isinstance(sample_id, str) else [str(s) for s in sample_id]
+
+    # Normalize instance_id → list[int] or None
+    _iid_filter = None
+    if instance_id is not None:
+        _iid_filter = [int(instance_id)] if isinstance(instance_id, int) else [int(x) for x in instance_id]
+
+    # Normalize columns filter
+    _col_filter = None
+    if columns is not None and not (isinstance(columns, str) and columns.lower() == "all"):
+        _col_filter = [columns] if isinstance(columns, str) else list(columns)
+
+    logger.info(
+        "write_dataframe: resolved filters → columns=%s, sample_id=%s, instance_id=%s",
+        _col_filter if _col_filter is not None else "<all>",
+        _sid_filter if _sid_filter is not None else "<all>",
+        _iid_filter if _iid_filter is not None else "<all>",
+    )
+
+    # Resolve output path (same convention as write_history)
+    _base = _os.path.basename(path)
+    if not _os.path.splitext(_base)[1] or _os.path.isdir(path):
+        _params_key = (
+            "dataframe",
+            tuple(sorted(_col_filter)) if _col_filter is not None else None,
+            tuple(sorted(_sid_filter)) if _sid_filter is not None else None,
+            tuple(sorted(_iid_filter)) if _iid_filter is not None else None,
+        )
+        _phash = _hashlib.md5(str(_params_key).encode()).hexdigest()[:8]
+        path = _os.path.join(path, f"{_phash}_dataframe.{fmt}")
+        logger.info("write_dataframe: auto-generated filename %r (params hash %s).",
+                    _os.path.basename(path), _phash)
+    _os.makedirs(_os.path.dirname(_os.path.abspath(path)), exist_ok=True)
+    logger.info("write_dataframe: output file → %s", _os.path.abspath(path))
+
+    # Flush pending buffer to H5 before reading
+    try:
+        _dm.flush()
+        logger.debug("write_dataframe: buffer flushed to H5.")
+    except Exception as _e:
+        logger.warning("write_dataframe: flush failed (%s); proceeding with "
+                       "in-memory data only.", _e)
+
+    # Retrieve the full dataframe
+    try:
+        _df = _dm.get_combined_df()
+    except Exception as _e:
+        logger.error("write_dataframe: failed to retrieve dataframe (%s).", _e)
+        raise
+
+    import pandas as _pd
+    if _df is None or _df.empty:
+        logger.warning("write_dataframe: dataframe is empty; writing empty output.")
+        _df = _pd.DataFrame()
+
+    df_out = _df
+
+    # Filter by sample_id (MultiIndex level 0)
+    if _sid_filter is not None and not df_out.empty:
+        _sid_set = set(_sid_filter)
+        mask = df_out.index.get_level_values(0).astype(str).isin(_sid_set)
+        df_out = df_out.loc[mask]
+        logger.debug("write_dataframe: after sample_id filter → %d row(s).", len(df_out))
+
+    # Filter by instance_id / annotation_id (MultiIndex level 1)
+    if _iid_filter is not None and not df_out.empty:
+        _iid_set = set(_iid_filter)
+        try:
+            mask = df_out.index.get_level_values(1).astype(int).isin(_iid_set)
+            df_out = df_out.loc[mask]
+        except Exception:
+            pass  # non-integer annotation_ids — skip this filter
+        logger.debug("write_dataframe: after instance_id filter → %d row(s).", len(df_out))
+
+    # Filter columns by group or exact name
+    if _col_filter is not None and not df_out.empty:
+        _selected: list = []
+        for _item in _col_filter:
+            _lc = str(_item).lower()
+            if _lc == "tags":
+                _selected += [
+                    c for c in df_out.columns
+                    if str(c).startswith("tag:") or str(c).startswith("TAG:")
+                ]
+            elif _lc == "signals":
+                _selected += [
+                    c for c in df_out.columns
+                    if str(c).lower().startswith("signals")
+                ]
+            elif _lc == "discarded":
+                if "discarded" in df_out.columns:
+                    _selected.append("discarded")
+            else:
+                if _item in df_out.columns:
+                    _selected.append(_item)
+        _selected = list(dict.fromkeys(_selected))  # deduplicate, preserve order
+        df_out = df_out[_selected] if _selected else df_out[[]]
+        logger.debug("write_dataframe: column filter → %d column(s): %s",
+                     len(_selected), _selected)
+
+    # Reset index so sample_id / annotation_id appear as regular columns in output
+    df_out = df_out.reset_index()
+
+    if fmt == "json":
+        _json_str = df_out.to_json(orient="records", default_handler=str)
+        with open(path, "w", encoding="utf-8") as fh:
+            _json.dump(_json.loads(_json_str), fh, indent=2)
+
+    elif fmt == "csv":
+        df_out.to_csv(path, index=False, encoding="utf-8")
+
+    else:
+        logger.error("write_dataframe: unsupported format %r (expected 'json' or 'csv').", format)
+        raise ValueError(
+            f"write_dataframe: unsupported format {format!r}. Use 'json' or 'csv'."
+        )
+
+    logger.info(
+        "write_dataframe: wrote %d row(s) × %d column(s) as %s to %s",
+        len(df_out), len(df_out.columns), fmt, _os.path.abspath(path),
+    )
+    if df_out.empty:
+        logger.warning(
+            "write_dataframe: output is empty — no rows matched the given filters "
+            "(sample_id=%r, instance_id=%r).",
+            _sid_filter, _iid_filter,
+        )
+
+    return path
+
+
 # ##############################################################################################################
 # MAIN EXAMPLES USAGE (can be called from training script to manually set)
 # ##############################################################################################################

--- a/weightslab/src.py
+++ b/weightslab/src.py
@@ -29,7 +29,7 @@ from weightslab.trainer.trainer_services import grpc_serve
 from weightslab.data.sample_stats import SampleStatsEx
 from weightslab.utils.logs import set_log_directory
 from weightslab.utils.tools import detach_to_cpu
-from weightslab.utils.logger import LoggerQueue
+from weightslab.backend.logger import LoggerQueue
 from weightslab.utils.tools import ddp_info, is_main_process
 from weightslab.backend.cli import cli_serve
 from weightslab.backend import ledgers
@@ -83,12 +83,12 @@ class SignalContext:
     Unified context object for WeightsLab signals.
     Carries all available metadata for a single sample during computation.
     """
-    def __init__(self, sample_id, dataframe, data=None, subscribed_value=None, subscribed_history=None, origin=None):
+    def __init__(self, sample_id, dataframe, data=None, subscribed_value=None, logger=None, origin=None):
         self.sample_id = sample_id
         self.dataframe = dataframe
         self.data = data
         self.subscribed_value = subscribed_value
-        self.subscribed_history = subscribed_history
+        self.logger = logger
         self.origin = origin
 
     @property
@@ -569,9 +569,6 @@ def wrappered_fwd(original_forward, kwargs, reg_name, *a, **kw):
                  subscribers.append((name, func))
 
          if subscribers:
-             # Get logger history
-             signal_history_per_sample = ledgers.get_logger().get_current_signaL_history_per_sample(reg_name, sample_ids=ids_np) if meta.get('include_history', False) else None
-
              # Resolve generic value vector
              val_tensor = out
              if hasattr(val_tensor, 'detach'):
@@ -626,7 +623,7 @@ def wrappered_fwd(original_forward, kwargs, reg_name, *a, **kw):
                              ctx = SignalContext(
                                  sample_id=int(uid),
                                  subscribed_value=val,
-                                 subscribed_history=signal_history_per_sample.get(uid) if signal_history_per_sample is not None else None,
+                                 logger=ledgers.get_logger(),
                                  dataframe=df_proxy,
                                  origin=kwargs.get('origin', 'train')
                              )
@@ -1400,7 +1397,7 @@ def register_categorical_tag(name: str, categories: list[str], replace: bool = F
     from weightslab.backend.ledgers import get_dataframe
 
     df_manager = get_dataframe()
-    if df_manager is None:
+    if df_manager == None:
         logger.error("Dataframe manager not initialized. Call this after registering your dataloader.")
         return []
     try:
@@ -1946,6 +1943,27 @@ def save_instance_signals(
         step=step,
         targets=targets,
     )
+
+    # Mirror scalar instance signals into the per-instance logger history so they
+    # are queryable via query_instance_history / query_per_instance.
+    try:
+        _inst_logger = get_logger()
+        if _inst_logger is not None and hasattr(_inst_logger, "add_instance_scalars"):
+            _log_step = step if step is not None else 0
+            for _key, _arr in losses_data.items():
+                _sig_name = _key.replace("signals//", "")
+                try:
+                    _inst_logger.add_instance_scalars(
+                        graph_name=_sig_name,
+                        sample_ids=instance_sample_ids,
+                        annotation_ids=instance_annotation_ids,
+                        values=_arr,
+                        global_step=_log_step,
+                    )
+                except Exception:
+                    pass
+    except Exception:
+        pass
 
 
 def get_active_group_mask(
@@ -2997,6 +3015,427 @@ class _EvalManagedLoader:
                 progress_total,
                 f"Evaluating '{self._split_name}'…",
             )
+
+
+# ##############################################################################################################
+# SIGNAL HISTORY QUERY HELPERS
+# ##############################################################################################################
+
+def get_current_experiment_hash() -> str | None:
+    """Return the hash of the currently active experiment run.
+
+    Reads the hash from the registered checkpoint manager.  Returns ``None``
+    when no experiment is active or no checkpoint manager has been registered.
+
+    Example::
+
+        h = wl.get_current_experiment_hash()
+        wl.write_history("/tmp/run", experiment_hash=h)
+    """
+    try:
+        cm = get_checkpoint_manager()
+        if cm is None:
+            return None
+        h = cm.get_current_experiment_hash()
+        return h if isinstance(h, str) else None
+    except Exception:
+        return None
+
+
+def query_signal_history(
+    signal_name: str,
+    exp_hash: str | None = None,
+) -> list:
+    """Return per-sample history for *signal_name* across all samples.
+
+    Returns a list of ``(sample_id, step, value, experiment_hash)`` tuples.
+    Pass *exp_hash* to restrict to a single experiment run.
+
+    Example::
+
+        history = wl.query_signal_history("train/loss")
+        for sample_id, step, loss, h in history:
+            print(sample_id, step, loss)
+    """
+    _lg = get_logger()
+    if _lg is None:
+        return []
+    return _lg.query_per_sample(signal_name, sample_ids=None, exp_hash=exp_hash)
+
+
+def query_sample_history(
+    sample_id: str,
+    signal_name: str | None = None,
+    exp_hash: str | None = None,
+) -> list:
+    """Return the full logged history for a given *sample_id*.
+
+    Returns a list of ``(signal_name, step, value, experiment_hash)`` tuples.
+    Pass *signal_name* to restrict to a single metric; pass *exp_hash* to
+    restrict to a single experiment run.
+
+    Example::
+
+        for sig, step, val, h in wl.query_sample_history("img_0042"):
+            print(sig, step, val)
+    """
+    _lg = get_logger()
+    if _lg is None:
+        return []
+    names = (
+        [signal_name]
+        if signal_name
+        else list(_lg._signal_history_per_sample.keys())
+    )
+    results = []
+    for name in names:
+        for sid, step, val, h in _lg.query_per_sample(
+            name, sample_ids=[sample_id], exp_hash=exp_hash
+        ):
+            results.append((name, step, val, h))
+    return results
+
+
+def query_instance_history(
+    sample_id: str,
+    annotation_id: int,
+    signal_name: str | None = None,
+    exp_hash: str | None = None,
+) -> list:
+    """Return the full logged history for a ``(sample_id, annotation_id)`` instance.
+
+    *annotation_id* is 1-based (0 is the per-sample row; instances start at 1).
+    Returns a list of ``(signal_name, step, value, experiment_hash)`` tuples.
+
+    Example::
+
+        for sig, step, val, h in wl.query_instance_history("img_0042", annotation_id=1):
+            print(sig, step, val)
+    """
+    _lg = get_logger()
+    if _lg is None:
+        return []
+    names = (
+        [signal_name]
+        if signal_name
+        else list(_lg._signal_history_per_instance.keys())
+    )
+    results = []
+    for name in names:
+        for sid, aid, step, val, h in _lg.query_per_instance(
+            name, sample_id=sample_id, annotation_id=annotation_id, exp_hash=exp_hash
+        ):
+            results.append((name, step, val, h))
+    return results
+
+
+def write_history(
+    path: str | None = None,
+    format: str = "json",
+    type_of_history=None,
+    graph_name=None,
+    experiment_hash: str | None = None,
+    sample_id=None,
+    instance_id=None,
+) -> str:
+    """Dump signal history to *path* as JSON or CSV.
+
+    Parameters
+    ----------
+    path : str, optional
+        Output file path **or** directory.  When omitted (``None``), the
+        ``root_log_dir`` from the active checkpoint manager is used as the
+        output directory.
+
+        - If *path* points to a file (has an extension) the file is written
+          directly.
+        - If *path* has no extension or is an existing directory, a filename
+          is auto-generated as ``<hash>_history.<format>`` inside that
+          directory, where ``<hash>`` is an 8-character hex MD5 of the
+          normalized call parameters (*type_of_history*, *graph_name*,
+          *experiment_hash*, *sample_id*, *instance_id*).  The same filter
+          combination always produces the same filename; different filters
+          produce different filenames.
+        - The directory is created automatically if it does not exist.
+    format : {"json", "csv"}
+        Output format (default ``"json"``).
+    type_of_history : {None, "all", "global", "sample", "instance", "instances"}
+        Which history to include.  ``None`` or ``"all"`` writes every type.
+        ``"global"`` writes the aggregated training-curve history.
+        ``"sample"`` writes per-sample history.
+        ``"instance"`` / ``"instances"`` writes per-instance history.
+    graph_name : str or list of str, optional
+        Restrict to one or more signal / metric names.
+    experiment_hash : str, optional
+        ``None`` (default) — use the current experiment hash from the
+        checkpoint manager.  ``"all"`` — include every hash.
+        Any other string — restrict to that specific experiment run.
+    sample_id : str or list of str, optional
+        Restrict per-sample and per-instance rows to one or more sample IDs.
+        Has no effect on global history.
+    instance_id : int or list of int, optional
+        Restrict per-instance rows to one or more annotation IDs.
+        Has no effect on global or per-sample history.
+
+    Returns
+    -------
+    str
+        Absolute path of the file that was written.
+
+    Examples
+    --------
+    Write all history — directory inferred from ``root_log_dir``::
+
+        wl.write_history()
+
+    Write all history into a specific directory::
+
+        wl.write_history(r"C:\\tmp\\myrun")
+
+    Write only per-sample data for one experiment to CSV::
+
+        wl.write_history(
+            r"C:\\tmp\\myrun",
+            format="csv",
+            type_of_history="sample",
+            experiment_hash="abc123",
+        )
+    """
+    import csv as _csv
+    import json as _json
+    import os as _os
+    import hashlib as _hashlib
+
+    logger.debug(
+        "write_history called: path=%r, format=%r, type_of_history=%r, "
+        "graph_name=%r, experiment_hash=%r, sample_id=%r, instance_id=%r",
+        path, format, type_of_history, graph_name, experiment_hash,
+        sample_id, instance_id,
+    )
+
+    _lg = get_logger()
+    if _lg is None:
+        logger.warning(
+            "write_history: no active logger (get_logger() returned None); "
+            "nothing to write. Returning path=%r.", path or "."
+        )
+        return path or "."
+
+    # Resolve path: fall back to root_log_dir from the checkpoint manager
+    if path is None:
+        try:
+            _cm = _lg.chkpt_manager
+            if _cm is not None:
+                _rld = _cm.root_log_dir
+                path = str(_rld) if _rld is not None else "."
+            else:
+                path = "."
+        except Exception as _e:
+            logger.debug("write_history: failed to resolve root_log_dir (%s); "
+                         "falling back to current directory.", _e)
+            path = "."
+        logger.info("write_history: no path given, using output directory %r.", path)
+
+    fmt = format.lower().strip()
+
+    # --- Normalize all parameters first (needed for the auto-filename hash) ---
+
+    # Resolve experiment_hash:
+    #   None      → use the current hash from the checkpoint manager (default)
+    #   "all"     → no filter, include every hash
+    #   any str   → filter to that specific hash
+    if experiment_hash is None or experiment_hash == 'last':
+        try:
+            _current = (
+                _lg.chkpt_manager.get_current_experiment_hash()
+                if _lg.chkpt_manager is not None
+                else None
+            )
+            experiment_hash = _current if isinstance(_current, str) else None
+        except Exception:
+            experiment_hash = None
+    elif experiment_hash == "all":
+        experiment_hash = None  # sentinel: skip hash filtering below
+
+    # Normalize graph_name → set or None
+    _gn_filter = None
+    if graph_name is not None:
+        _gn_filter = {graph_name} if isinstance(graph_name, str) else set(graph_name)
+
+    # Normalize sample_id → list or None
+    _sid_filter = None
+    if sample_id is not None:
+        _sid_filter = [sample_id] if isinstance(sample_id, str) else list(sample_id)
+
+    # Normalize instance_id → list or None
+    _aid_filter = None
+    if instance_id is not None:
+        _aid_filter = [instance_id] if isinstance(instance_id, int) else list(instance_id)
+
+    _type = (type_of_history or "all").lower().strip()
+    if _type == "instances":
+        _type = "instance"
+    write_global = _type in ("all", "global")
+    write_sample = _type in ("all", "sample")
+    write_instance = _type in ("all", "instance")
+
+    logger.info(
+        "write_history: resolved filters → type=%r, experiment_hash=%s, "
+        "graph_name=%s, sample_id=%s, instance_id=%s",
+        _type,
+        experiment_hash if experiment_hash is not None else "<all>",
+        sorted(_gn_filter) if _gn_filter is not None else "<all>",
+        _sid_filter if _sid_filter is not None else "<all>",
+        _aid_filter if _aid_filter is not None else "<all>",
+    )
+
+    # --- Resolve output path ---
+    # When path has no file extension (or is an existing directory), generate a
+    # filename from a short hash of the normalized call parameters so that the
+    # same filter combination always produces the same filename.
+    _base = _os.path.basename(path)
+    if not _os.path.splitext(_base)[1] or _os.path.isdir(path):
+        _params_key = (
+            _type,
+            tuple(sorted(_gn_filter)) if _gn_filter is not None else None,
+            experiment_hash,
+            tuple(sorted(_sid_filter)) if _sid_filter is not None else None,
+            tuple(sorted(int(x) for x in _aid_filter)) if _aid_filter is not None else None,
+        )
+        _phash = _hashlib.md5(str(_params_key).encode()).hexdigest()[:8]
+        path = _os.path.join(path, f"{_phash}_history.{fmt}")
+        logger.info("write_history: auto-generated filename %r (params hash "
+                    "%s).", _os.path.basename(path), _phash)
+    _os.makedirs(_os.path.dirname(_os.path.abspath(path)), exist_ok=True)
+    logger.info("write_history: output file → %s", _os.path.abspath(path))
+
+    global_rows: list = []
+    sample_rows: list = []
+    instance_rows: list = []
+
+    if write_global:
+        for gn, hashes in _lg._signal_history.items():
+            if _gn_filter is not None and gn not in _gn_filter:
+                continue
+            for h, steps in hashes.items():
+                if experiment_hash is not None and h != experiment_hash:
+                    continue
+                for step, entries in steps.items():
+                    for entry in entries:
+                        val = (
+                            entry.get("metric_value")
+                            if isinstance(entry, dict)
+                            else float(entry)
+                        )
+                        global_rows.append({
+                            "graph_name": gn,
+                            "experiment_hash": h if h is not None else "",
+                            "step": step,
+                            "metric_value": val,
+                        })
+        logger.debug("write_history: collected %d global row(s).",
+                     len(global_rows))
+
+    if write_sample:
+        graphs_s = (
+            list(_gn_filter)
+            if _gn_filter is not None
+            else list(_lg._signal_history_per_sample.keys())
+        )
+        for gn in graphs_s:
+            for sid, step, val, h in _lg.query_per_sample(
+                gn,
+                sample_ids=_sid_filter,
+                exp_hash=experiment_hash,
+            ):
+                sample_rows.append({
+                    "graph_name": gn,
+                    "experiment_hash": h if h is not None else "",
+                    "sample_id": sid,
+                    "step": step,
+                    "metric_value": val,
+                })
+        logger.debug("write_history: collected %d sample row(s) across %d "
+                     "graph(s).", len(sample_rows), len(graphs_s))
+
+    if write_instance:
+        graphs_i = (
+            list(_gn_filter)
+            if _gn_filter is not None
+            else list(_lg._signal_history_per_instance.keys())
+        )
+        # query_per_instance filters by a single (sample_id, annotation_id); iterate when multiple given
+        _sid_iter = _sid_filter if _sid_filter is not None else [None]
+        _aid_iter = _aid_filter if _aid_filter is not None else [None]
+        for gn in graphs_i:
+            for _sid in _sid_iter:
+                for _aid in _aid_iter:
+                    for sid, aid, step, val, h in _lg.query_per_instance(
+                        gn,
+                        sample_id=_sid,
+                        annotation_id=_aid,
+                        exp_hash=experiment_hash,
+                    ):
+                        instance_rows.append({
+                            "graph_name": gn,
+                            "experiment_hash": h if h is not None else "",
+                            "sample_id": sid,
+                            "annotation_id": aid,
+                            "step": step,
+                            "metric_value": val,
+                        })
+        logger.debug("write_history: collected %d instance row(s) across %d "
+                     "graph(s).", len(instance_rows), len(graphs_i))
+
+    if fmt == "json":
+        payload = {}
+        if write_global:
+            payload["global"] = global_rows
+        if write_sample:
+            payload["sample"] = sample_rows
+        if write_instance:
+            payload["instance"] = instance_rows
+        with open(path, "w", encoding="utf-8") as fh:
+            _json.dump(payload, fh, indent=2)
+
+    elif fmt == "csv":
+        _CSV_FIELDS = [
+            "type", "graph_name", "experiment_hash", "step", "metric_value",
+            "sample_id", "annotation_id",
+        ]
+        with open(path, "w", newline="", encoding="utf-8") as fh:
+            writer = _csv.DictWriter(fh, fieldnames=_CSV_FIELDS, extrasaction="ignore")
+            writer.writeheader()
+            for row in global_rows:
+                writer.writerow({"type": "global", **row})
+            for row in sample_rows:
+                writer.writerow({"type": "sample", **row})
+            for row in instance_rows:
+                writer.writerow({"type": "instance", **row})
+
+    else:
+        logger.error("write_history: unsupported format %r (expected 'json' "
+                     "or 'csv').", format)
+        raise ValueError(
+            f"write_history: unsupported format {format!r}. Use 'json' or 'csv'."
+        )
+
+    _total = len(global_rows) + len(sample_rows) + len(instance_rows)
+    logger.info(
+        "write_history: wrote %d row(s) (global=%d, sample=%d, instance=%d) "
+        "as %s to %s",
+        _total, len(global_rows), len(sample_rows), len(instance_rows),
+        fmt, _os.path.abspath(path),
+    )
+    if _total == 0:
+        logger.warning(
+            "write_history: output is empty — no rows matched the given "
+            "filters (type=%r, experiment_hash=%r). Check that the signals "
+            "have been logged for the requested experiment hash.",
+            _type, experiment_hash,
+        )
+
+    return path
 
 
 # ##############################################################################################################

--- a/weightslab/src.py
+++ b/weightslab/src.py
@@ -18,7 +18,7 @@ import numpy as np
 import torch as th
 
 from tqdm import tqdm
-from typing import Callable, Optional, Any, Dict
+from typing import Callable, Optional, Any
 
 from weightslab.backend.dataloader_interface import DataLoaderInterface
 from weightslab.components.checkpoint_manager import CheckpointManager
@@ -1865,12 +1865,6 @@ def save_instance_signals(
 
     step = _get_step(step=step)
 
-    # Normalize batch_ids to list of strings (matching ledger format)
-    if isinstance(batch_ids, th.Tensor):
-        batch_ids_list = [str(i) for i in batch_ids.detach().cpu().tolist()]
-    else:
-        batch_ids_list = [str(i) for i in batch_ids]
-
     # Normalize batch_idx to numpy ints (per-instance → batch-position map)
     if isinstance(batch_idx, th.Tensor):
         batch_idx_np = batch_idx.detach().cpu().numpy().astype(int).flatten()
@@ -3510,7 +3504,6 @@ def write_dataframe(
             sample_id=["img_001", "img_042"],
         )
     """
-    import csv as _csv
     import json as _json
     import os as _os
     import hashlib as _hashlib

--- a/weightslab/tests/backend/test_instance_signal_logger.py
+++ b/weightslab/tests/backend/test_instance_signal_logger.py
@@ -1,0 +1,719 @@
+"""Tests for per-instance signal history logging and querying.
+
+Covers:
+- LoggerQueue.add_instance_scalars / query_per_instance
+- query_per_sample bug-fix (early-exit now returns [] not {})
+- save_snapshot / load_snapshot round-trip for instance history
+- get_signal_history_per_instance reconstruction
+- Public API: query_signal_history, query_sample_history, query_instance_history
+- break_by_slices aggregation (basic + robustness with many samples)
+"""
+
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+
+from weightslab.backend.logger import LoggerQueue
+from weightslab.backend import ledgers
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_logger() -> LoggerQueue:
+    """Unregistered LoggerQueue with no checkpoint manager."""
+    lg = LoggerQueue(register=False)
+    lg.chkpt_manager = None
+    return lg
+
+
+def _make_service(signal_logger, df_manager):
+    """Create a minimal ExperimentService for break_by_slices testing."""
+    from weightslab.trainer.services.experiment_service import ExperimentService
+
+    svc = ExperimentService.__new__(ExperimentService)
+    ctx = MagicMock()
+    ctx.ensure_components = MagicMock()
+    ctx.components = {"signal_logger": signal_logger, "df_manager": df_manager}
+    ctx.get = ctx.components.get
+    svc._ctx = ctx
+    svc.model_service = MagicMock()
+    svc.data_service = MagicMock()
+    svc.audit_logger = None
+    svc._logger_data_in_flight = 0
+    svc._logger_data_counter_lock = threading.Lock()
+    return svc
+
+
+def _make_df(tagged_ids, all_ids, tag="hard"):
+    """MultiIndex DataFrame with a single boolean tag column."""
+    idx = pd.MultiIndex.from_tuples(
+        [(sid, 0) for sid in all_ids], names=["sample_id", "annotation_id"]
+    )
+    return pd.DataFrame({f"tag:{tag}": [sid in tagged_ids for sid in all_ids]}, index=idx)
+
+
+def _ctx_mock():
+    ctx = MagicMock()
+    ctx.is_active.return_value = True
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# 1. add_instance_scalars + query_per_instance
+# ---------------------------------------------------------------------------
+
+class TestAddInstanceScalars(unittest.TestCase):
+
+    def test_stores_scalars_and_queryable(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars(
+            "confidence", ["s0", "s0", "s1"], [1, 2, 1],
+            np.array([0.9, 0.8, 0.7], dtype=np.float32), 10, "h1",
+        )
+        rows = lg.query_per_instance("confidence")
+        self.assertEqual(len(rows), 3)
+        self.assertIn("s0", {r[0] for r in rows})
+        self.assertIn("s1", {r[0] for r in rows})
+
+    def test_filter_by_sample_id(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("conf", ["a", "a", "b"], [1, 2, 1], [0.9, 0.8, 0.5], 5, "h1")
+        rows = lg.query_per_instance("conf", sample_id="a")
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(r[0] == "a" for r in rows))
+
+    def test_filter_by_annotation_id(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("conf", ["a", "a", "b"], [1, 2, 1], [0.9, 0.8, 0.5], 5, "h1")
+        rows = lg.query_per_instance("conf", annotation_id=1)
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(r[1] == 1 for r in rows))
+
+    def test_filter_by_sample_and_annotation(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("conf", ["a", "a", "b"], [1, 2, 1], [0.9, 0.8, 0.5], 5, "h1")
+        rows = lg.query_per_instance("conf", sample_id="a", annotation_id=2)
+        self.assertEqual(len(rows), 1)
+        self.assertAlmostEqual(rows[0][3], 0.8, places=4)
+
+    def test_filter_by_exp_hash(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("conf", ["a"], [1], [0.9], 5, "h1")
+        lg.add_instance_scalars("conf", ["b"], [1], [0.1], 5, "h2")
+        rows = lg.query_per_instance("conf", exp_hash="h1")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][4], "h1")
+
+    def test_tuple_fields(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("iou", ["img1"], [3], [0.75], 100, "run1")
+        sid, aid, step, val, h = lg.query_per_instance("iou")[0]
+        self.assertEqual(sid, "img1")
+        self.assertEqual(aid, 3)
+        self.assertEqual(step, 100)
+        self.assertAlmostEqual(val, 0.75, places=4)
+        self.assertEqual(h, "run1")
+
+    def test_unknown_signal_returns_empty_list(self):
+        lg = _fresh_logger()
+        self.assertEqual(lg.query_per_instance("nonexistent"), [])
+
+    def test_multiple_steps_accumulated(self):
+        lg = _fresh_logger()
+        for step in range(5):
+            lg.add_instance_scalars(
+                "loss", ["s0", "s1"], [1, 1],
+                [float(step), float(step) * 2], step, "h1",
+            )
+        self.assertEqual(len(lg.query_per_instance("loss")), 10)
+
+    def test_list_values_accepted(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("score", ["x", "y"], [1, 1], [0.3, 0.6], 1, "h1")
+        self.assertEqual(len(lg.query_per_instance("score")), 2)
+
+    def test_none_exp_hash_stored(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("sig", ["s"], [1], [1.0], 0, None)
+        rows = lg.query_per_instance("sig")
+        self.assertEqual(len(rows), 1)
+        self.assertIsNone(rows[0][4])
+
+
+# ---------------------------------------------------------------------------
+# 2. query_per_sample early-exit bug fix (was returning {} instead of [])
+# ---------------------------------------------------------------------------
+
+class TestQueryPerSampleBugFix(unittest.TestCase):
+
+    def test_unknown_signal_returns_list_not_dict(self):
+        lg = _fresh_logger()
+        result = lg.query_per_sample("no_such_signal")
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, [])
+
+    def test_known_signal_returns_list(self):
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"s0": 0.5}, aggregate_by_step=False)
+        self.assertIsInstance(lg.query_per_sample("loss"), list)
+
+    def test_returns_correct_tuples(self):
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.4}, 2,
+                       signal_per_sample={"img0": 0.4}, aggregate_by_step=False)
+        rows = lg.query_per_sample("loss")
+        self.assertEqual(len(rows), 1)
+        sid, step, val, h = rows[0]
+        self.assertEqual(str(sid), "img0")
+        self.assertEqual(step, 2)
+        self.assertAlmostEqual(val, 0.4, places=4)
+
+    def test_filter_by_sample_ids(self):
+        lg = _fresh_logger()
+        for sid in ["a", "b", "c"]:
+            lg.add_scalars("loss", {"loss": 1.0}, 1,
+                           signal_per_sample={sid: 1.0}, aggregate_by_step=False)
+        rows = lg.query_per_sample("loss", sample_ids=["a", "c"])
+        found = {r[0] for r in rows}
+        self.assertIn("a", found)
+        self.assertIn("c", found)
+        self.assertNotIn("b", found)
+
+
+# ---------------------------------------------------------------------------
+# 3. save_snapshot / load_snapshot round-trip
+# ---------------------------------------------------------------------------
+
+class TestSnapshotRoundTrip(unittest.TestCase):
+
+    def test_instance_history_survives_round_trip(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("iou", ["s0", "s1"], [1, 2], [0.8, 0.6], 10, "h1")
+        snap = lg.save_snapshot()
+        self.assertIn("signal_history_per_instance", snap)
+        lg2 = _fresh_logger()
+        lg2.load_snapshot(snap)
+        self.assertEqual(len(lg2.query_per_instance("iou")), 2)
+
+    def test_sample_and_instance_coexist_in_snapshot(self):
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"img0": 0.5}, aggregate_by_step=False)
+        lg.add_instance_scalars("iou", ["img0"], [1], [0.9], 1, "h1")
+        snap = lg.save_snapshot()
+        lg2 = _fresh_logger()
+        lg2.load_snapshot(snap)
+        self.assertEqual(len(lg2.query_per_sample("loss")), 1)
+        self.assertEqual(len(lg2.query_per_instance("iou")), 1)
+
+    def test_old_snapshot_without_instance_key_is_safe(self):
+        lg = _fresh_logger()
+        lg.load_snapshot({"graph_names": [], "signal_history": {}, "signal_history_per_sample": {}})
+        self.assertEqual(lg.query_per_instance("loss"), [])
+
+    def test_values_preserved_after_round_trip(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars(
+            "conf",
+            [f"s{i}" for i in range(20)],
+            list(range(1, 21)),
+            [float(i) * 0.1 for i in range(20)],
+            global_step=5,
+            exp_hash="h1",
+        )
+        snap = lg.save_snapshot()
+        lg2 = _fresh_logger()
+        lg2.load_snapshot(snap)
+        self.assertEqual(len(lg2.query_per_instance("conf")), 20)
+
+
+# ---------------------------------------------------------------------------
+# 4. get_signal_history_per_instance reconstruction
+# ---------------------------------------------------------------------------
+
+class TestGetSignalHistoryPerInstance(unittest.TestCase):
+
+    def test_structure(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("iou", ["s0"], [1], [0.7], 3, "h1")
+        hist = lg.get_signal_history_per_instance()
+        self.assertIn("iou", hist)
+        self.assertIn("h1", hist["iou"])
+        entry = hist["iou"]["h1"][0]
+        self.assertEqual(entry["sample_id"], "s0")
+        self.assertEqual(entry["annotation_id"], 1)
+        self.assertEqual(entry["model_age"], 3)
+        self.assertAlmostEqual(entry["metric_value"], 0.7, places=4)
+
+
+# ---------------------------------------------------------------------------
+# 5. Public API: query_signal_history, query_sample_history, query_instance_history
+# ---------------------------------------------------------------------------
+
+class TestPublicQueryAPI(unittest.TestCase):
+
+    def setUp(self):
+        ledgers.clear_all()
+        self.lg = LoggerQueue(register=True)
+        self.lg.chkpt_manager = None
+
+    def tearDown(self):
+        ledgers.clear_all()
+
+    def _add_sample(self, sig, sid, step, val):
+        self.lg.add_scalars(sig, {sig: val}, step,
+                            signal_per_sample={sid: val}, aggregate_by_step=False)
+
+    def _add_instance(self, sig, sid, aid, step, val):
+        self.lg.add_instance_scalars(sig, [sid], [aid], [val], step, "h1")
+
+    def test_query_signal_history_all(self):
+        from weightslab.src import query_signal_history
+        self._add_sample("loss", "img0", 1, 0.5)
+        self._add_sample("loss", "img1", 1, 0.3)
+        rows = query_signal_history("loss")
+        self.assertEqual(len(rows), 2)
+
+    def test_query_signal_history_unknown_hash_returns_empty(self):
+        from weightslab.src import query_signal_history
+        self._add_sample("loss", "img0", 1, 0.5)
+        rows = query_signal_history("loss", exp_hash="nonexistent_hash")
+        self.assertEqual(rows, [])
+
+    def test_query_sample_history_all_signals(self):
+        from weightslab.src import query_sample_history
+        self._add_sample("loss", "img0", 1, 0.5)
+        self._add_sample("acc", "img0", 1, 0.9)
+        self._add_sample("loss", "img1", 1, 0.3)
+        rows = query_sample_history("img0")
+        signals = {r[0] for r in rows}
+        self.assertIn("loss", signals)
+        self.assertIn("acc", signals)
+
+    def test_query_sample_history_single_signal(self):
+        from weightslab.src import query_sample_history
+        self._add_sample("loss", "img0", 1, 0.5)
+        self._add_sample("acc", "img0", 1, 0.9)
+        rows = query_sample_history("img0", signal_name="loss")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], "loss")
+
+    def test_query_sample_history_unknown_returns_empty(self):
+        from weightslab.src import query_sample_history
+        self._add_sample("loss", "img0", 1, 0.5)
+        self.assertEqual(query_sample_history("ghost_sample"), [])
+
+    def test_query_instance_history_single_instance(self):
+        from weightslab.src import query_instance_history
+        self._add_instance("iou", "img0", 1, 5, 0.8)
+        self._add_instance("iou", "img0", 2, 5, 0.6)
+        self._add_instance("iou", "img1", 1, 5, 0.4)
+        rows = query_instance_history("img0", annotation_id=1)
+        self.assertEqual(len(rows), 1)
+        self.assertAlmostEqual(rows[0][2], 0.8, places=4)
+
+    def test_query_instance_history_all_signals(self):
+        from weightslab.src import query_instance_history
+        self._add_instance("iou", "img0", 1, 5, 0.8)
+        self._add_instance("conf", "img0", 1, 5, 0.9)
+        rows = query_instance_history("img0", annotation_id=1)
+        self.assertIn("iou", {r[0] for r in rows})
+        self.assertIn("conf", {r[0] for r in rows})
+
+    def test_query_instance_history_unknown_returns_empty(self):
+        from weightslab.src import query_instance_history
+        self.assertEqual(query_instance_history("ghost", annotation_id=99), [])
+
+
+# ---------------------------------------------------------------------------
+# 6. Reverse index correctness
+# ---------------------------------------------------------------------------
+
+class TestReverseIndex(unittest.TestCase):
+
+    def test_sample_index_built_on_add(self):
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"img0": 0.5, "img1": 0.3}, aggregate_by_step=False)
+        idx = lg._sample_index.get("loss", {})
+        self.assertTrue(any("img0" in h_idx for h_idx in idx.values()))
+
+    def test_sample_index_points_to_correct_rows(self):
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"img0": 0.5}, aggregate_by_step=False)
+        lg.add_scalars("loss", {"loss": 0.3}, 2,
+                       signal_per_sample={"img0": 0.3}, aggregate_by_step=False)
+        # img0 appears twice — both rows should be indexed
+        h = list(lg._sample_index["loss"].keys())[0]
+        rows = lg._sample_index["loss"][h]["img0"]
+        self.assertEqual(len(rows), 2)
+        buf = list(lg._signal_history_per_sample["loss"].values())[0]
+        self.assertEqual(buf["steps"][rows[0]], 1)
+        self.assertEqual(buf["steps"][rows[1]], 2)
+
+    def test_instance_index_built_on_add(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("iou", ["s0", "s0", "s1"], [1, 2, 1], [0.9, 0.8, 0.7], 5, "h1")
+        idx = lg._instance_index["iou"]["h1"]
+        self.assertIn(("s0", 1), idx)
+        self.assertIn(("s0", 2), idx)
+        self.assertIn(("s1", 1), idx)
+
+    def test_instance_index_points_to_correct_values(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("iou", ["s0", "s0"], [1, 1], [0.9, 0.8], 5, "h1")
+        # Same (s0, 1) at two different steps → two rows
+        idx = lg._instance_index["iou"]["h1"]
+        rows = idx[("s0", 1)]
+        self.assertEqual(len(rows), 2)
+
+    def test_sample_index_rebuilt_after_snapshot_load(self):
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.4}, 1,
+                       signal_per_sample={"img0": 0.4, "img1": 0.6}, aggregate_by_step=False)
+        snap = lg.save_snapshot()
+        lg2 = _fresh_logger()
+        lg2.load_snapshot(snap)
+        self.assertIn("img0", list(lg2._sample_index.get("loss", {}).values())[0])
+        self.assertIn("img1", list(lg2._sample_index.get("loss", {}).values())[0])
+
+    def test_instance_index_rebuilt_after_snapshot_load(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("iou", ["s0", "s1"], [1, 2], [0.8, 0.6], 3, "h1")
+        snap = lg.save_snapshot()
+        lg2 = _fresh_logger()
+        lg2.load_snapshot(snap)
+        idx = lg2._instance_index.get("iou", {}).get("h1", {})
+        self.assertIn(("s0", 1), idx)
+        self.assertIn(("s1", 2), idx)
+
+    def test_clear_signal_histories_also_clears_indices(self):
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"img0": 0.5}, aggregate_by_step=False)
+        lg.add_instance_scalars("iou", ["s0"], [1], [0.8], 1, "h1")
+        lg.clear_signal_histories()
+        self.assertEqual(lg._sample_index, {})
+        self.assertEqual(lg._instance_index, {})
+
+    def test_query_uses_index_not_full_scan(self):
+        """query_per_sample with filter returns correct results via index path."""
+        lg = _fresh_logger()
+        for i in range(100):
+            lg.add_scalars("loss", {"loss": float(i)}, i,
+                           signal_per_sample={f"s{i}": float(i)}, aggregate_by_step=False)
+        rows = lg.query_per_sample("loss", sample_ids=["s5", "s42"])
+        sids = {r[0] for r in rows}
+        self.assertEqual(sids, {"s5", "s42"})
+        self.assertEqual(len(rows), 2)
+
+    def test_eval_mode_also_updates_sample_index(self):
+        """Index must be maintained during evaluation mode (for break-by-slices on eval data)."""
+        lg = _fresh_logger()
+        lg._eval_mode_active = True
+        lg._eval_mode_hash = "eval_h1"
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"imgA": 0.5, "imgB": 0.3}, aggregate_by_step=False)
+        lg._eval_mode_active = False
+        idx = lg._sample_index.get("loss", {}).get("eval_h1", {})
+        self.assertIn("imgA", idx)
+        self.assertIn("imgB", idx)
+        # Query must find them
+        rows = lg.query_per_sample("loss", sample_ids=["imgA"])
+        self.assertEqual(len(rows), 1)
+
+    def test_legacy_list_of_dicts_snapshot_rebuilds_index(self):
+        """Old list-of-dicts format must still rebuild _sample_index on load."""
+        lg = _fresh_logger()
+        legacy_snap = {
+            "graph_names": ["loss"],
+            "signal_history": {},
+            "signal_history_per_sample": {
+                "loss": {
+                    "h1": [
+                        {"sample_id": "img0", "model_age": 1, "metric_value": 0.4},
+                        {"sample_id": "img1", "model_age": 1, "metric_value": 0.6},
+                    ]
+                }
+            },
+        }
+        lg.load_snapshot(legacy_snap)
+        idx = lg._sample_index.get("loss", {}).get("h1", {})
+        self.assertIn("img0", idx)
+        self.assertIn("img1", idx)
+        rows = lg.query_per_sample("loss", sample_ids=["img0"])
+        self.assertEqual(len(rows), 1)
+
+    def test_multi_exp_hash_filter(self):
+        """query_per_sample with exp_hash filter only returns rows from that hash."""
+        lg = _fresh_logger()
+        lg.add_scalars("loss", {"loss": 0.1}, 1,
+                       signal_per_sample={"s0": 0.1}, aggregate_by_step=False)
+        # Manually inject a second hash entry to simulate two runs
+        from array import array as _array
+        lg._signal_history_per_sample["loss"]["h2"] = {
+            "sample_ids": ["s0"],
+            "steps": _array('i', [1]),
+            "values": _array('f', [0.9]),
+        }
+        lg._sample_index.setdefault("loss", {}).setdefault("h2", {})["s0"] = [0]
+        rows_h2 = lg.query_per_sample("loss", sample_ids=["s0"], exp_hash="h2")
+        self.assertEqual(len(rows_h2), 1)
+        self.assertAlmostEqual(rows_h2[0][2], 0.9, places=4)
+
+    def test_query_instance_uses_index_both_filters(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("conf", ["a", "a", "b"], [1, 2, 1], [0.9, 0.8, 0.5], 5, "h1")
+        rows = lg.query_per_instance("conf", sample_id="a", annotation_id=2)
+        self.assertEqual(len(rows), 1)
+        self.assertAlmostEqual(rows[0][3], 0.8, places=4)
+
+    def test_query_instance_sample_only_filter(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("conf", ["a", "a", "b"], [1, 2, 1], [0.9, 0.8, 0.5], 5, "h1")
+        rows = lg.query_per_instance("conf", sample_id="a")
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(r[0] == "a" for r in rows))
+
+    def test_query_instance_annotation_only_filter(self):
+        lg = _fresh_logger()
+        lg.add_instance_scalars("conf", ["a", "a", "b"], [1, 2, 1], [0.9, 0.8, 0.5], 5, "h1")
+        rows = lg.query_per_instance("conf", annotation_id=1)
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(r[1] == 1 for r in rows))
+
+
+# ---------------------------------------------------------------------------
+# 7. aggregate_per_sample_by_step (numpy vectorized aggregation)
+# ---------------------------------------------------------------------------
+
+class TestAggregatePerSampleByStep(unittest.TestCase):
+
+    def _add(self, lg, sig, sid, step, val, h="h1"):
+        lg.add_scalars(sig, {sig: val}, step,
+                       signal_per_sample={sid: val}, aggregate_by_step=False)
+
+    def test_single_step_mean(self):
+        lg = _fresh_logger()
+        self._add(lg, "loss", "s0", 1, 0.4)
+        self._add(lg, "loss", "s1", 1, 0.6)
+        result = lg.aggregate_per_sample_by_step("loss")
+        h = list(result.keys())[0]
+        self.assertEqual(len(result[h]), 1)
+        self.assertAlmostEqual(result[h][0][1], 0.5, places=4)
+
+    def test_multiple_steps(self):
+        lg = _fresh_logger()
+        self._add(lg, "loss", "s0", 1, 0.2)
+        self._add(lg, "loss", "s0", 2, 0.4)
+        self._add(lg, "loss", "s1", 1, 0.6)
+        self._add(lg, "loss", "s1", 2, 0.8)
+        result = lg.aggregate_per_sample_by_step("loss")
+        h = list(result.keys())[0]
+        by_step = dict(result[h])
+        self.assertAlmostEqual(by_step[1], 0.4, places=4)
+        self.assertAlmostEqual(by_step[2], 0.6, places=4)
+
+    def test_sample_id_filter(self):
+        lg = _fresh_logger()
+        self._add(lg, "loss", "s0", 1, 0.2)
+        self._add(lg, "loss", "s1", 1, 0.8)
+        result = lg.aggregate_per_sample_by_step("loss", sample_ids=["s0"])
+        h = list(result.keys())[0]
+        self.assertAlmostEqual(result[h][0][1], 0.2, places=4)
+
+    def test_unknown_signal_returns_empty(self):
+        lg = _fresh_logger()
+        self.assertEqual(lg.aggregate_per_sample_by_step("no_signal"), {})
+
+    def test_filtered_to_empty_returns_empty(self):
+        lg = _fresh_logger()
+        self._add(lg, "loss", "s0", 1, 0.5)
+        result = lg.aggregate_per_sample_by_step("loss", sample_ids=["ghost"])
+        self.assertEqual(result, {})
+
+    def test_large_sample_count_correct_mean(self):
+        lg = _fresh_logger()
+        N = 10_000
+        for i in range(N):
+            lg.add_scalars("loss", {"loss": float(i) / N}, 0,
+                           signal_per_sample={str(i): float(i) / N}, aggregate_by_step=False)
+        result = lg.aggregate_per_sample_by_step("loss")
+        h = list(result.keys())[0]
+        expected = np.mean([float(i) / N for i in range(N)])
+        self.assertAlmostEqual(result[h][0][1], expected, places=3)
+
+    def test_series_ordered_by_step(self):
+        lg = _fresh_logger()
+        for step in [5, 2, 8, 1, 3]:
+            lg.add_scalars("loss", {"loss": float(step)}, step,
+                           signal_per_sample={"s0": float(step)}, aggregate_by_step=False)
+        result = lg.aggregate_per_sample_by_step("loss")
+        h = list(result.keys())[0]
+        steps = [s for s, _ in result[h]]
+        self.assertEqual(steps, sorted(steps))
+
+
+# ---------------------------------------------------------------------------
+# 8. break_by_slices — basic correctness (using real logger + numpy path)
+# ---------------------------------------------------------------------------
+
+class TestBreakBySlicesBasic(unittest.TestCase):
+
+    def _sl_from_pts(self, pts):
+        """Build a real LoggerQueue seeded with (sid, step, val, exp_hash) tuples."""
+        lg = _fresh_logger()
+        for sid, step, val, h in pts:
+            lg.add_scalars("loss", {"loss": val}, step,
+                           signal_per_sample={sid: val}, aggregate_by_step=False)
+        return lg
+
+    def _req(self, pb2, tags, graph_name):
+        return pb2.GetLatestLoggerDataRequest(
+            break_by_slices=True, tags=tags, graph_name=graph_name,
+        )
+
+    def test_mean_curve_basic(self):
+        import weightslab.proto.experiment_service_pb2 as pb2
+        sl = self._sl_from_pts([("s0", 1, 0.4, None), ("s1", 1, 0.6, None)])
+        svc = _make_service(sl, MagicMock(get_df_view=lambda: _make_df({"s0", "s1"}, ["s0", "s1", "s2"])))
+        resp = svc._get_latest_logger_data_impl(self._req(pb2, ["hard"], "loss"), _ctx_mock())
+        self.assertEqual(len(resp.points), 1)
+        self.assertAlmostEqual(resp.points[0].metric_value, 0.5, places=4)
+        self.assertEqual(resp.points[0].sample_id, "")
+
+    def test_excludes_untagged_samples(self):
+        import weightslab.proto.experiment_service_pb2 as pb2
+        sl = self._sl_from_pts([("s0", 1, 0.2, None), ("s1", 1, 0.8, None)])
+        svc = _make_service(sl, MagicMock(get_df_view=lambda: _make_df({"s0"}, ["s0", "s1"])))
+        resp = svc._get_latest_logger_data_impl(self._req(pb2, ["hard"], "loss"), _ctx_mock())
+        self.assertEqual(len(resp.points), 1)
+        self.assertAlmostEqual(resp.points[0].metric_value, 0.2, places=4)
+
+    def test_empty_tag_match_returns_empty(self):
+        import weightslab.proto.experiment_service_pb2 as pb2
+        sl = _fresh_logger()
+        svc = _make_service(sl, MagicMock(get_df_view=lambda: _make_df(set(), ["s0"])))
+        resp = svc._get_latest_logger_data_impl(self._req(pb2, ["missing_tag"], "loss"), _ctx_mock())
+        self.assertEqual(len(resp.points), 0)
+
+    def test_multiple_steps_averaged_correctly(self):
+        import weightslab.proto.experiment_service_pb2 as pb2
+        sl = self._sl_from_pts([
+            ("s0", 1, 0.2, None), ("s0", 2, 0.4, None),
+            ("s1", 1, 0.6, None), ("s1", 2, 0.8, None),
+        ])
+        svc = _make_service(sl, MagicMock(get_df_view=lambda: _make_df({"s0", "s1"}, ["s0", "s1"])))
+        resp = svc._get_latest_logger_data_impl(self._req(pb2, ["hard"], "loss"), _ctx_mock())
+        by_step = {p.model_age: p.metric_value for p in resp.points}
+        self.assertAlmostEqual(by_step[1], 0.4, places=4)
+        self.assertAlmostEqual(by_step[2], 0.6, places=4)
+
+
+# ---------------------------------------------------------------------------
+# 9. break_by_slices — robustness with large sample counts
+# ---------------------------------------------------------------------------
+
+class TestBreakBySlicesRobustness(unittest.TestCase):
+
+    def _req(self, pb2, tags, graph_name):
+        return pb2.GetLatestLoggerDataRequest(
+            break_by_slices=True, tags=tags, graph_name=graph_name,
+        )
+
+    def _tagged_df(self, n):
+        all_ids = [str(i) for i in range(n)]
+        idx = pd.MultiIndex.from_tuples(
+            [(sid, 0) for sid in all_ids], names=["sample_id", "annotation_id"]
+        )
+        return pd.DataFrame({"tag:hard": [True] * n}, index=idx)
+
+    def _seeded_logger(self, n_samples, n_steps=1, fixed_val=None):
+        lg = _fresh_logger()
+        rng = np.random.default_rng(42)
+        for i in range(n_samples):
+            for s in range(n_steps):
+                val = fixed_val if fixed_val is not None else float(rng.random())
+                lg.add_scalars("loss", {"loss": val}, s,
+                               signal_per_sample={str(i): val}, aggregate_by_step=False)
+        return lg
+
+    def test_10k_samples_correct_mean(self):
+        import weightslab.proto.experiment_service_pb2 as pb2
+        N = 10_000
+        sl = _fresh_logger()
+        for i in range(N):
+            sl.add_scalars("loss", {"loss": float(i) / N}, 0,
+                           signal_per_sample={str(i): float(i) / N}, aggregate_by_step=False)
+        svc = _make_service(sl, MagicMock(get_df_view=lambda: self._tagged_df(N)))
+        resp = svc._get_latest_logger_data_impl(self._req(pb2, ["hard"], "loss"), _ctx_mock())
+        self.assertEqual(len(resp.points), 1)
+        expected = np.mean([float(i) / N for i in range(N)])
+        self.assertAlmostEqual(resp.points[0].metric_value, expected, places=3)
+
+    def test_output_capped_by_max_points(self):
+        import weightslab.proto.experiment_service_pb2 as pb2
+        from weightslab.trainer.services.experiment_service import _max_points_per_sample
+        N, S = 200, 600
+        sl = self._seeded_logger(N, S)
+        svc = _make_service(sl, MagicMock(get_df_view=lambda: self._tagged_df(N)))
+        resp = svc._get_latest_logger_data_impl(self._req(pb2, ["hard"], "loss"), _ctx_mock())
+        cap = _max_points_per_sample()
+        if cap > 0:
+            self.assertLessEqual(len(resp.points), cap)
+
+    def test_fixed_value_mean_numerically_exact(self):
+        import weightslab.proto.experiment_service_pb2 as pb2
+        N, fixed = 5_000, 0.314159
+        sl = self._seeded_logger(N, fixed_val=fixed)
+        svc = _make_service(sl, MagicMock(get_df_view=lambda: self._tagged_df(N)))
+        resp = svc._get_latest_logger_data_impl(self._req(pb2, ["hard"], "loss"), _ctx_mock())
+        self.assertEqual(len(resp.points), 1)
+        self.assertAlmostEqual(resp.points[0].metric_value, fixed, places=4)
+
+
+# ---------------------------------------------------------------------------
+# 10. Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety(unittest.TestCase):
+
+    def test_concurrent_add_and_query(self):
+        lg = _fresh_logger()
+        errors = []
+
+        def writer(idx):
+            try:
+                for step in range(20):
+                    lg.add_instance_scalars(
+                        "sig", [f"s{idx}_{step}"], [1], [float(step)], step, "h1",
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        def reader():
+            try:
+                for _ in range(50):
+                    lg.query_per_instance("sig")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(4)]
+        threads += [threading.Thread(target=reader) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [], f"Concurrency errors: {errors}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weightslab/tests/backend/test_logger_core.py
+++ b/weightslab/tests/backend/test_logger_core.py
@@ -16,7 +16,6 @@ Covers all previously untested public methods:
 - load_signal_history (dict format, list format)
 """
 
-import time
 import unittest
 from unittest.mock import MagicMock
 

--- a/weightslab/tests/backend/test_logger_core.py
+++ b/weightslab/tests/backend/test_logger_core.py
@@ -1,0 +1,726 @@
+"""Tests for LoggerQueue core methods.
+
+Covers all previously untested public methods:
+- __len__
+- get_next_evaluation_count
+- start_evaluation_mode / stop_evaluation_mode / abort_evaluation_mode
+- remove_evaluation_hash
+- add_scalars (aggregate_by_step=True/False, eval mode, buffering)
+- ingest_per_sample (dedup, index update)
+- get_current_signaL_history (meta=True/False)
+- get_current_signaL_history_per_sample
+- get_signal_history / get_signal_history_per_sample
+- get_evaluation_marker_hashes
+- get_and_clear_queue
+- set_point_note
+- load_signal_history (dict format, list format)
+"""
+
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from weightslab.backend.logger import LoggerQueue
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _lg() -> LoggerQueue:
+    """Unregistered LoggerQueue with no checkpoint manager (exp_hash = None)."""
+    lg = LoggerQueue(register=False)
+    lg.chkpt_manager = None
+    return lg
+
+
+def _add(lg, sig, sid, step, val, aggregate_by_step=False):
+    lg.add_scalars(sig, {sig: val}, step,
+                   signal_per_sample={sid: val},
+                   aggregate_by_step=aggregate_by_step)
+
+
+# ---------------------------------------------------------------------------
+# 1. __len__
+# ---------------------------------------------------------------------------
+
+class TestLen(unittest.TestCase):
+
+    def test_empty_logger_is_zero(self):
+        lg = _lg()
+        self.assertEqual(len(lg), 0)
+
+    def test_after_one_signal_immediate(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        # _signal_history has step 1 → len = 1
+        self.assertEqual(len(lg), 1)
+
+    def test_multiple_steps_returns_max(self):
+        lg = _lg()
+        for step in range(5):
+            _add(lg, "loss", "s0", step, float(step))
+        self.assertEqual(len(lg), 5)
+
+    def test_multiple_signals_returns_max_across_all(self):
+        lg = _lg()
+        for step in range(3):
+            _add(lg, "loss", "s0", step, 0.1)
+        for step in range(7):
+            _add(lg, "acc", "s0", step, 0.9)
+        self.assertEqual(len(lg), 7)
+
+
+# ---------------------------------------------------------------------------
+# 2. get_next_evaluation_count
+# ---------------------------------------------------------------------------
+
+class TestGetNextEvaluationCount(unittest.TestCase):
+
+    def test_no_existing_evals_returns_1(self):
+        lg = _lg()
+        self.assertEqual(lg.get_next_evaluation_count("h1"), 1)
+
+    def test_existing_h1_1_returns_2(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1_1": {}}
+        self.assertEqual(lg.get_next_evaluation_count("h1"), 2)
+
+    def test_existing_h1_1_and_h1_3_returns_4(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1_1": {}, "h1_3": {}}
+        self.assertEqual(lg.get_next_evaluation_count("h1"), 4)
+
+    def test_non_int_suffix_is_ignored(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1_abc": {}, "h1_1": {}}
+        self.assertEqual(lg.get_next_evaluation_count("h1"), 2)
+
+    def test_different_base_hash_not_counted(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h2_5": {}}
+        self.assertEqual(lg.get_next_evaluation_count("h1"), 1)
+
+
+# ---------------------------------------------------------------------------
+# 3. start_evaluation_mode / stop_evaluation_mode
+# ---------------------------------------------------------------------------
+
+class TestEvaluationMode(unittest.TestCase):
+
+    def test_start_sets_active_flag(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        self.assertTrue(lg._eval_mode_active)
+        self.assertEqual(lg._eval_mode_hash, "h1_1")
+        self.assertEqual(lg._eval_mode_split, "val")
+
+    def test_start_resets_accum(self):
+        lg = _lg()
+        lg._eval_accum = {"loss": [99.0, 10]}
+        lg.start_evaluation_mode("val", "h1_1")
+        self.assertEqual(lg._eval_accum, {})
+
+    def test_add_scalars_during_eval_goes_to_accum_not_history(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.4}, 10,
+                       signal_per_sample=None, aggregate_by_step=False)
+        self.assertIn("loss", lg._eval_accum)
+        self.assertNotIn("loss", lg._signal_history)
+
+    def test_add_scalars_during_eval_accumulates_values(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.4}, 10,
+                       signal_per_sample=None, aggregate_by_step=False)
+        lg.add_scalars("loss", {"loss": 0.6}, 10,
+                       signal_per_sample=None, aggregate_by_step=False)
+        total, count = lg._eval_accum["loss"]
+        self.assertAlmostEqual(total, 1.0, places=5)
+        self.assertEqual(count, 2)
+
+    def test_stop_computes_mean_and_writes_history(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.4}, 10, signal_per_sample=None, aggregate_by_step=False)
+        lg.add_scalars("loss", {"loss": 0.6}, 10, signal_per_sample=None, aggregate_by_step=False)
+        results = lg.stop_evaluation_mode(model_age=10)
+        self.assertIn("loss", results)
+        self.assertAlmostEqual(results["loss"], 0.5, places=5)
+        # Written into _signal_history under eval_hash
+        self.assertIn("h1_1", lg._signal_history.get("loss", {}))
+
+    def test_stop_emits_is_evaluation_marker(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.5}, 10, signal_per_sample=None, aggregate_by_step=False)
+        lg.stop_evaluation_mode(model_age=10)
+        entries = lg._signal_history["loss"]["h1_1"][10]
+        self.assertTrue(entries[0].get("is_evaluation_marker"))
+
+    def test_stop_adds_to_pending_queue(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.5}, 10, signal_per_sample=None, aggregate_by_step=False)
+        lg.stop_evaluation_mode(model_age=10)
+        hashes_in_queue = {e.get("experiment_hash") for e in lg._pending_queue}
+        self.assertIn("h1_1", hashes_in_queue)
+
+    def test_stop_resets_eval_state(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.stop_evaluation_mode(model_age=5)
+        self.assertFalse(lg._eval_mode_active)
+        self.assertEqual(lg._eval_mode_hash, "")
+        self.assertEqual(lg._eval_accum, {})
+
+    def test_stop_when_not_active_returns_empty(self):
+        lg = _lg()
+        self.assertEqual(lg.stop_evaluation_mode(model_age=1), {})
+
+    def test_stop_skips_zero_count_signals(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg._eval_accum["loss"] = [0.0, 0]  # injected directly with count=0
+        results = lg.stop_evaluation_mode(model_age=1)
+        self.assertNotIn("loss", results)
+
+    def test_stop_stores_split_name_and_tags(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1", evaluation_tags=["hard", "easy"])
+        lg.add_scalars("loss", {"loss": 0.5}, 1, signal_per_sample=None, aggregate_by_step=False)
+        lg.stop_evaluation_mode(model_age=1)
+        entry = lg._signal_history["loss"]["h1_1"][1][0]
+        self.assertEqual(entry["split_name"], "val")
+        self.assertEqual(entry["evaluation_tags"], ["hard", "easy"])
+
+    def test_per_sample_still_written_during_eval(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"img0": 0.5, "img1": 0.3},
+                       aggregate_by_step=True)
+        rows = lg.query_per_sample("loss", exp_hash="h1_1")
+        self.assertEqual(len(rows), 2)
+
+
+# ---------------------------------------------------------------------------
+# 4. abort_evaluation_mode
+# ---------------------------------------------------------------------------
+
+class TestAbortEvaluationMode(unittest.TestCase):
+
+    def test_abort_when_not_active_is_noop(self):
+        lg = _lg()
+        lg.abort_evaluation_mode()  # should not raise
+        self.assertFalse(lg._eval_mode_active)
+
+    def test_abort_clears_active_flag_and_accum(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.5}, 1, signal_per_sample=None, aggregate_by_step=False)
+        lg.abort_evaluation_mode()
+        self.assertFalse(lg._eval_mode_active)
+        self.assertEqual(lg._eval_accum, {})
+
+    def test_abort_removes_per_sample_written_during_eval(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"img0": 0.5}, aggregate_by_step=True)
+        lg.abort_evaluation_mode()
+        # Per-sample history under "h1_1" should be gone
+        self.assertNotIn("h1_1", lg._signal_history_per_sample.get("loss", {}))
+
+    def test_abort_removes_queue_entries_for_eval_hash(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        # Stop first so queue has entries, then simulate abort on a second eval
+        lg.add_scalars("loss", {"loss": 0.5}, 1, signal_per_sample=None, aggregate_by_step=False)
+        # Manually inject a queue entry for the eval hash
+        lg._pending_queue.append({"experiment_hash": "h1_1", "metric_name": "loss"})
+        lg._eval_mode_active = True  # re-arm
+        lg.abort_evaluation_mode()
+        hashes_in_queue = {e.get("experiment_hash") for e in lg._pending_queue}
+        self.assertNotIn("h1_1", hashes_in_queue)
+
+
+# ---------------------------------------------------------------------------
+# 5. remove_evaluation_hash
+# ---------------------------------------------------------------------------
+
+class TestRemoveEvaluationHash(unittest.TestCase):
+
+    def test_removes_from_signal_history(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1_1": {1: []}, "h1": {1: []}}
+        lg.remove_evaluation_hash("h1_1")
+        self.assertNotIn("h1_1", lg._signal_history["loss"])
+        self.assertIn("h1", lg._signal_history["loss"])
+
+    def test_removes_from_per_sample_history(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        # manually inject an eval hash entry
+        from array import array as _array
+        lg._signal_history_per_sample["loss"]["h1_1"] = {
+            "sample_ids": ["s0"], "steps": _array('i', [1]), "values": _array('f', [0.5])
+        }
+        lg.remove_evaluation_hash("h1_1")
+        self.assertNotIn("h1_1", lg._signal_history_per_sample["loss"])
+
+    def test_removes_matching_entries_from_queue(self):
+        lg = _lg()
+        lg._pending_queue = [
+            {"experiment_hash": "h1_1", "metric_name": "loss"},
+            {"experiment_hash": "h1",   "metric_name": "loss"},
+        ]
+        lg.remove_evaluation_hash("h1_1")
+        self.assertEqual(len(lg._pending_queue), 1)
+        self.assertEqual(lg._pending_queue[0]["experiment_hash"], "h1")
+
+    def test_empty_hash_is_noop(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1": {}}
+        lg.remove_evaluation_hash("")
+        self.assertIn("h1", lg._signal_history["loss"])
+
+    def test_missing_hash_does_not_raise(self):
+        lg = _lg()
+        lg.remove_evaluation_hash("nonexistent_hash_1")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 6. add_scalars — aggregate_by_step paths
+# ---------------------------------------------------------------------------
+
+class TestAddScalars(unittest.TestCase):
+
+    def test_immediate_mode_writes_to_history(self):
+        lg = _lg()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"s0": 0.5}, aggregate_by_step=False)
+        self.assertIn(None, lg._signal_history.get("loss", {}))
+        self.assertEqual(lg._signal_history["loss"][None][1][0]["metric_value"], 0.5)
+
+    def test_immediate_mode_adds_to_queue(self):
+        lg = _lg()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample=None, aggregate_by_step=False)
+        self.assertEqual(len(lg._pending_queue), 1)
+
+    def test_aggregate_mode_buffers_not_writes(self):
+        lg = _lg()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"s0": 0.5}, aggregate_by_step=True)
+        # Not in history yet — buffered
+        self.assertNotIn("loss", lg._signal_history)
+        self.assertIn((1, "loss", None), lg._current_step_buffer)
+
+    def test_aggregate_mode_step_change_flushes_to_history(self):
+        lg = _lg()
+        lg.add_scalars("loss", {"loss": 0.4}, 1,
+                       signal_per_sample={"s0": 0.4}, aggregate_by_step=True)
+        lg.add_scalars("loss", {"loss": 0.6}, 1,
+                       signal_per_sample={"s1": 0.6}, aggregate_by_step=True)
+        # Step change triggers flush
+        lg.add_scalars("loss", {"loss": 0.9}, 2,
+                       signal_per_sample={"s0": 0.9}, aggregate_by_step=True)
+        # Step 1 should now be averaged in history
+        entries = lg._signal_history["loss"][None][1]
+        self.assertAlmostEqual(entries[0]["metric_value"], 0.5, places=5)
+
+    def test_aggregate_mode_averages_multiple_calls_same_step(self):
+        lg = _lg()
+        for v in [0.2, 0.4, 0.6]:
+            lg.add_scalars("loss", {"loss": v}, 1,
+                           signal_per_sample={f"s{v}": v}, aggregate_by_step=True)
+        # Force flush
+        lg.add_scalars("acc", {"acc": 0.9}, 2,
+                       signal_per_sample=None, aggregate_by_step=False)
+        entries = lg._signal_history["loss"][None][1]
+        self.assertAlmostEqual(entries[0]["metric_value"], 0.4, places=5)
+
+    def test_per_sample_written_even_in_aggregate_mode(self):
+        lg = _lg()
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample={"img0": 0.5, "img1": 0.3}, aggregate_by_step=True)
+        rows = lg.query_per_sample("loss")
+        self.assertEqual(len(rows), 2)
+
+    def test_graph_name_added_to_graph_names(self):
+        lg = _lg()
+        lg.add_scalars("my_signal", {"my_signal": 1.0}, 1,
+                       signal_per_sample=None, aggregate_by_step=False)
+        self.assertIn("my_signal", lg.graph_names)
+
+
+# ---------------------------------------------------------------------------
+# 7. ingest_per_sample
+# ---------------------------------------------------------------------------
+
+class TestIngestPerSample(unittest.TestCase):
+
+    def test_adds_new_triples(self):
+        lg = _lg()
+        lg.ingest_per_sample("loss", "h1", [("s0", 1, 0.4), ("s1", 1, 0.6)])
+        rows = lg.query_per_sample("loss")
+        self.assertEqual(len(rows), 2)
+
+    def test_dedup_same_sample_and_step(self):
+        lg = _lg()
+        lg.ingest_per_sample("loss", "h1", [("s0", 1, 0.4)])
+        lg.ingest_per_sample("loss", "h1", [("s0", 1, 0.9)])  # same (sid, step) → ignored
+        rows = lg.query_per_sample("loss")
+        self.assertEqual(len(rows), 1)
+        self.assertAlmostEqual(rows[0][2], 0.4, places=4)
+
+    def test_different_step_is_not_dedup(self):
+        lg = _lg()
+        lg.ingest_per_sample("loss", "h1", [("s0", 1, 0.4)])
+        lg.ingest_per_sample("loss", "h1", [("s0", 2, 0.9)])  # different step → accepted
+        rows = lg.query_per_sample("loss")
+        self.assertEqual(len(rows), 2)
+
+    def test_empty_triples_is_noop(self):
+        lg = _lg()
+        lg.ingest_per_sample("loss", "h1", [])
+        self.assertEqual(lg.query_per_sample("loss"), [])
+
+    def test_updates_sample_index(self):
+        lg = _lg()
+        lg.ingest_per_sample("loss", "h1", [("img5", 1, 0.5)])
+        rows = lg.query_per_sample("loss", sample_ids=["img5"])
+        self.assertEqual(len(rows), 1)
+
+    def test_dedup_does_not_corrupt_index(self):
+        lg = _lg()
+        lg.ingest_per_sample("loss", "h1", [("s0", 1, 0.4)])
+        lg.ingest_per_sample("loss", "h1", [("s0", 1, 0.9)])  # duplicate ignored
+        # index should still point to exactly 1 row
+        idx = lg._sample_index["loss"]["h1"]["s0"]
+        self.assertEqual(len(idx), 1)
+
+
+# ---------------------------------------------------------------------------
+# 8. get_current_signaL_history
+# ---------------------------------------------------------------------------
+
+class TestGetCurrentSignalHistory(unittest.TestCase):
+
+    def test_unknown_graph_returns_empty_dict(self):
+        lg = _lg()
+        self.assertEqual(lg.get_current_signaL_history("no_signal"), {})
+
+    def test_meta_false_returns_list_of_age_value(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        result = lg.get_current_signaL_history("loss", meta=False)
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0]["model_age"], 1)
+        self.assertAlmostEqual(result[0]["metric_value"], 0.5, places=4)
+
+    def test_meta_true_returns_raw_step_dict(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        result = lg.get_current_signaL_history("loss", meta=True)
+        self.assertIsInstance(result, dict)
+        self.assertIn(1, result)
+
+    def test_uses_chkpt_manager_hash_when_set(self):
+        lg = _lg()
+        mock_cm = MagicMock()
+        mock_cm.get_current_experiment_hash.return_value = "hash_abc"
+        lg.chkpt_manager = mock_cm
+        # add under hash_abc
+        lg.add_scalars("loss", {"loss": 0.5}, 1, signal_per_sample=None, aggregate_by_step=False)
+        result = lg.get_current_signaL_history("loss", meta=False)
+        self.assertEqual(len(result), 1)
+
+
+# ---------------------------------------------------------------------------
+# 9. get_current_signaL_history_per_sample
+# ---------------------------------------------------------------------------
+
+class TestGetCurrentSignalHistoryPerSample(unittest.TestCase):
+
+    def test_unknown_graph_returns_empty(self):
+        lg = _lg()
+        self.assertEqual(lg.get_current_signaL_history_per_sample("no_signal"), {})
+
+    def test_returns_tuples_for_known_signal(self):
+        lg = _lg()
+        _add(lg, "loss", "img0", 1, 0.5)
+        result = lg.get_current_signaL_history_per_sample("loss")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+
+    def test_sample_ids_filter_applied(self):
+        lg = _lg()
+        _add(lg, "loss", "img0", 1, 0.5)
+        _add(lg, "loss", "img1", 1, 0.3)
+        result = lg.get_current_signaL_history_per_sample("loss", sample_ids=["img0"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0][0]), "img0")
+
+
+# ---------------------------------------------------------------------------
+# 10. get_signal_history
+# ---------------------------------------------------------------------------
+
+class TestGetSignalHistory(unittest.TestCase):
+
+    def test_returns_deepcopy(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        hist = lg.get_signal_history()
+        # Mutate the copy — internal state must not change
+        hist["loss"][None][1][0]["metric_value"] = 999.0
+        self.assertNotEqual(lg._signal_history["loss"][None][1][0]["metric_value"], 999.0)
+
+    def test_empty_when_nothing_added(self):
+        lg = _lg()
+        self.assertEqual(lg.get_signal_history(), {})
+
+    def test_contains_all_signals(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        _add(lg, "acc", "s0", 1, 0.9)
+        hist = lg.get_signal_history()
+        self.assertIn("loss", hist)
+        self.assertIn("acc", hist)
+
+
+# ---------------------------------------------------------------------------
+# 11. get_signal_history_per_sample
+# ---------------------------------------------------------------------------
+
+class TestGetSignalHistoryPerSample(unittest.TestCase):
+
+    def test_reconstructs_list_of_dicts(self):
+        lg = _lg()
+        _add(lg, "loss", "img0", 1, 0.4)
+        _add(lg, "loss", "img1", 1, 0.6)
+        hist = lg.get_signal_history_per_sample()
+        self.assertIn("loss", hist)
+        entries = list(hist["loss"].values())[0]
+        self.assertEqual(len(entries), 2)
+        keys = set(entries[0].keys())
+        self.assertTrue({"sample_id", "model_age", "metric_name", "metric_value", "experiment_hash"} <= keys)
+
+    def test_empty_when_nothing_added(self):
+        lg = _lg()
+        self.assertEqual(lg.get_signal_history_per_sample(), {})
+
+
+# ---------------------------------------------------------------------------
+# 12. get_evaluation_marker_hashes
+# ---------------------------------------------------------------------------
+
+class TestGetEvaluationMarkerHashes(unittest.TestCase):
+
+    def test_empty_when_no_eval(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        self.assertEqual(lg.get_evaluation_marker_hashes(), [])
+
+    def test_returns_eval_hashes(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1_1": {}, "h1_2": {}, "h1": {}}
+        hashes = lg.get_evaluation_marker_hashes()
+        self.assertIn("h1_1", hashes)
+        self.assertIn("h1_2", hashes)
+        self.assertNotIn("h1", hashes)
+
+    def test_returns_sorted(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1_3": {}, "h1_1": {}, "h1_2": {}}
+        self.assertEqual(lg.get_evaluation_marker_hashes(), ["h1_1", "h1_2", "h1_3"])
+
+    def test_non_int_suffix_excluded(self):
+        lg = _lg()
+        lg._signal_history["loss"] = {"h1_abc": {}, "h1_1": {}}
+        hashes = lg.get_evaluation_marker_hashes()
+        self.assertNotIn("h1_abc", hashes)
+        self.assertIn("h1_1", hashes)
+
+    def test_via_full_eval_lifecycle(self):
+        lg = _lg()
+        lg.start_evaluation_mode("val", "h1_1")
+        lg.add_scalars("loss", {"loss": 0.5}, 1, signal_per_sample=None, aggregate_by_step=False)
+        lg.stop_evaluation_mode(model_age=1)
+        self.assertIn("h1_1", lg.get_evaluation_marker_hashes())
+
+
+# ---------------------------------------------------------------------------
+# 13. get_and_clear_queue
+# ---------------------------------------------------------------------------
+
+class TestGetAndClearQueue(unittest.TestCase):
+
+    def test_returns_pending_entries(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        queue = lg.get_and_clear_queue()
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]["metric_name"], "loss")
+
+    def test_clears_queue_after_call(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        lg.get_and_clear_queue()
+        self.assertEqual(lg.get_and_clear_queue(), [])
+
+    def test_returns_copy_not_reference(self):
+        lg = _lg()
+        _add(lg, "loss", "s0", 1, 0.5)
+        queue = lg.get_and_clear_queue()
+        queue.append({"fake": True})
+        # Internal queue should still be empty
+        self.assertEqual(len(lg._pending_queue), 0)
+
+    def test_empty_queue_returns_empty_list(self):
+        lg = _lg()
+        self.assertEqual(lg.get_and_clear_queue(), [])
+
+
+# ---------------------------------------------------------------------------
+# 14. set_point_note
+# ---------------------------------------------------------------------------
+
+class TestSetPointNote(unittest.TestCase):
+    """set_point_note requires a non-empty string exp_hash.
+    We use a mock checkpoint manager to store data under a real hash string."""
+
+    def _lg_with_hash(self, h="run1"):
+        lg = _lg()
+        mock_cm = MagicMock()
+        mock_cm.get_current_experiment_hash.return_value = h
+        lg.chkpt_manager = mock_cm
+        return lg
+
+    def test_returns_false_for_empty_metric_name(self):
+        lg = _lg()
+        self.assertFalse(lg.set_point_note("", "h1", 1, "note"))
+
+    def test_returns_false_for_empty_exp_hash(self):
+        lg = _lg()
+        self.assertFalse(lg.set_point_note("loss", "", 1, "note"))
+
+    def test_returns_false_for_none_exp_hash(self):
+        # str(None or "") = "" → treated as empty → False
+        lg = _lg()
+        self.assertFalse(lg.set_point_note("loss", None, 1, "note"))
+
+    def test_set_note_on_history_entry(self):
+        lg = self._lg_with_hash("run1")
+        _add(lg, "loss", "s0", 5, 0.4)
+        result = lg.set_point_note("loss", "run1", 5, "my note")
+        self.assertTrue(result)
+        entry = lg._signal_history["loss"]["run1"][5][0]
+        self.assertEqual(entry["point_note"], "my note")
+
+    def test_clear_note_with_empty_string(self):
+        lg = self._lg_with_hash("run1")
+        _add(lg, "loss", "s0", 5, 0.4)
+        lg.set_point_note("loss", "run1", 5, "my note")
+        lg.set_point_note("loss", "run1", 5, "")
+        entry = lg._signal_history["loss"]["run1"][5][0]
+        self.assertNotIn("point_note", entry)
+
+    def test_updates_pending_queue_entry(self):
+        lg = self._lg_with_hash("run1")
+        _add(lg, "loss", "s0", 5, 0.4)
+        lg.set_point_note("loss", "run1", 5, "queue note")
+        queue_entry = next(e for e in lg._pending_queue if e["metric_name"] == "loss")
+        self.assertEqual(queue_entry.get("point_note"), "queue note")
+
+    def test_nonexistent_step_returns_false(self):
+        lg = self._lg_with_hash("run1")
+        _add(lg, "loss", "s0", 5, 0.4)
+        result = lg.set_point_note("loss", "run1", 99, "note")
+        self.assertFalse(result)
+
+    def test_does_not_modify_non_matching_queue_entries(self):
+        lg = self._lg_with_hash("run1")
+        _add(lg, "loss", "s0", 5, 0.4)
+        _add(lg, "acc",  "s0", 5, 0.9)
+        lg.set_point_note("loss", "run1", 5, "only loss")
+        acc_entry = next(e for e in lg._pending_queue if e["metric_name"] == "acc")
+        self.assertNotIn("point_note", acc_entry)
+
+
+# ---------------------------------------------------------------------------
+# 15. load_signal_history
+# ---------------------------------------------------------------------------
+
+class TestLoadSignalHistory(unittest.TestCase):
+
+    def test_dict_format_loads_correctly(self):
+        lg = _lg()
+        lg.load_signal_history({
+            "loss": {
+                "h1": {
+                    1: [{"model_age": 1, "metric_value": 0.5, "experiment_hash": "h1",
+                         "metric_name": "loss", "timestamp": 0}]
+                }
+            }
+        })
+        self.assertIn("loss", lg._signal_history)
+        self.assertIn("h1", lg._signal_history["loss"])
+        self.assertEqual(lg._signal_history["loss"]["h1"][1][0]["metric_value"], 0.5)
+
+    def test_dict_format_string_step_key_converted_to_int(self):
+        lg = _lg()
+        lg.load_signal_history({
+            "loss": {
+                "h1": {
+                    "42": [{"model_age": 42, "metric_value": 0.3, "experiment_hash": "h1",
+                             "metric_name": "loss", "timestamp": 0}]
+                }
+            }
+        })
+        self.assertIn(42, lg._signal_history["loss"]["h1"])
+
+    def test_list_format_loads_correctly(self):
+        lg = _lg()
+        lg.load_signal_history([
+            {"metric_name": "acc", "experiment_hash": "h1", "model_age": 3,
+             "metric_value": 0.9, "timestamp": 0},
+        ])
+        self.assertIn("acc", lg._signal_history)
+        self.assertEqual(lg._signal_history["acc"]["h1"][3][0]["metric_value"], 0.9)
+
+    def test_list_format_skips_entries_without_metric_name(self):
+        lg = _lg()
+        lg.load_signal_history([
+            {"experiment_hash": "h1", "model_age": 1, "metric_value": 0.5},
+        ])
+        self.assertEqual(lg._signal_history, {})
+
+    def test_empty_input_is_noop(self):
+        lg = _lg()
+        lg.load_signal_history({})
+        lg.load_signal_history([])
+        self.assertEqual(lg._signal_history, {})
+
+    def test_adds_to_graph_names(self):
+        lg = _lg()
+        lg.load_signal_history([
+            {"metric_name": "val_loss", "experiment_hash": "h1", "model_age": 1,
+             "metric_value": 0.2, "timestamp": 0},
+        ])
+        self.assertIn("val_loss", lg.graph_names)
+
+    def test_missing_fields_get_defaults(self):
+        lg = _lg()
+        lg.load_signal_history([
+            {"metric_name": "loss", "model_age": 5, "metric_value": 0.1},
+        ])
+        # experiment_hash defaults to None
+        self.assertIn(None, lg._signal_history["loss"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weightslab/tests/backend/test_write_dataframe.py
+++ b/weightslab/tests/backend/test_write_dataframe.py
@@ -1,0 +1,314 @@
+"""Tests for wl.write_dataframe — JSON/CSV dump of the sample dataframe."""
+import csv
+import json
+import os
+from unittest.mock import MagicMock, patch, call
+
+import pandas as pd
+import pytest
+
+from weightslab.src import write_dataframe
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_df():
+    """Return a minimal DataFrame matching WeightsLab's MultiIndex schema."""
+    index = pd.MultiIndex.from_tuples(
+        [("s1", 0), ("s1", 1), ("s2", 0), ("s2", 2)],
+        names=["sample_id", "annotation_id"],
+    )
+    return pd.DataFrame(
+        {
+            "origin": ["train", None, "val", None],
+            "discarded": [False, None, True, None],
+            "signals_loss": [0.8, None, 0.4, None],
+            "signals//iou": [None, 0.7, None, 0.6],
+            "tag:loss_shape": ["monotonic", None, "Flat_high", None],
+            "tag:weather": ["sunny", None, None, None],
+        },
+        index=index,
+    )
+
+
+def _make_manager(df=None):
+    """Return a mock dataframe manager."""
+    if df is None:
+        df = _make_df()
+    m = MagicMock()
+    m.get_combined_df.return_value = df
+    return m
+
+
+def _call(path, manager, **kwargs):
+    with patch("weightslab.src.get_dataframe", return_value=manager), \
+         patch("weightslab.src.get_logger", return_value=None):
+        return write_dataframe(path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mgr():
+    return _make_manager()
+
+
+@pytest.fixture()
+def tmp_json(tmp_path):
+    return str(tmp_path / "out.json")
+
+
+@pytest.fixture()
+def tmp_csv(tmp_path):
+    return str(tmp_path / "out.csv")
+
+
+# ---------------------------------------------------------------------------
+# Flush behavior
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframeFlush:
+    def test_flush_called_before_read(self, mgr, tmp_json):
+        _call(tmp_json, mgr)
+        mgr.flush.assert_called_once()
+
+    def test_flush_failure_does_not_abort(self, tmp_json):
+        mgr = _make_manager()
+        mgr.flush.side_effect = RuntimeError("H5 locked")
+        # Should not raise; proceeds with in-memory data
+        out = _call(tmp_json, mgr)
+        assert os.path.isfile(out)
+
+
+# ---------------------------------------------------------------------------
+# JSON structure
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframeJsonStructure:
+    def test_json_is_list_of_records(self, mgr, tmp_json):
+        _call(tmp_json, mgr)
+        data = json.loads(open(tmp_json).read())
+        assert isinstance(data, list)
+
+    def test_json_includes_index_as_columns(self, mgr, tmp_json):
+        _call(tmp_json, mgr)
+        data = json.loads(open(tmp_json).read())
+        assert "sample_id" in data[0]
+        assert "annotation_id" in data[0]
+
+    def test_json_all_rows_present_by_default(self, mgr, tmp_json):
+        _call(tmp_json, mgr)
+        data = json.loads(open(tmp_json).read())
+        assert len(data) == 4
+
+    def test_returns_written_path(self, mgr, tmp_json):
+        result = _call(tmp_json, mgr)
+        assert result == tmp_json
+
+
+# ---------------------------------------------------------------------------
+# CSV structure
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframeCsvStructure:
+    def test_csv_has_header(self, mgr, tmp_csv):
+        _call(tmp_csv, mgr, format="csv")
+        with open(tmp_csv) as fh:
+            reader = csv.DictReader(fh)
+            rows = list(reader)
+        assert "sample_id" in reader.fieldnames
+        assert "annotation_id" in reader.fieldnames
+
+    def test_csv_all_rows_present(self, mgr, tmp_csv):
+        _call(tmp_csv, mgr, format="csv")
+        with open(tmp_csv) as fh:
+            rows = list(csv.DictReader(fh))
+        assert len(rows) == 4
+
+    def test_csv_format_auto_generates_csv_extension(self, mgr, tmp_path):
+        out = _call(str(tmp_path / "out"), mgr, format="csv")
+        assert out.endswith(".csv")
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframePath:
+    def test_explicit_file_path_used_directly(self, mgr, tmp_json):
+        result = _call(tmp_json, mgr)
+        assert result == tmp_json
+        assert os.path.isfile(result)
+
+    def test_directory_auto_generates_filename(self, mgr, tmp_path):
+        import re
+        out = _call(str(tmp_path / "outdir"), mgr)
+        assert os.path.isfile(out)
+        assert re.match(r"[0-9a-f]{8}_dataframe\.json$", os.path.basename(out))
+
+    def test_directory_is_created_if_missing(self, mgr, tmp_path):
+        out = _call(str(tmp_path / "deep" / "dir"), mgr)
+        assert os.path.isfile(out)
+
+    def test_same_filters_same_filename(self, mgr, tmp_path):
+        out1 = _call(str(tmp_path), mgr, columns="signals", sample_id="s1")
+        out2 = _call(str(tmp_path), mgr, columns="signals", sample_id="s1")
+        assert os.path.basename(out1) == os.path.basename(out2)
+
+    def test_different_filters_different_filenames(self, mgr, tmp_path):
+        out1 = _call(str(tmp_path), mgr, columns="tags")
+        out2 = _call(str(tmp_path), mgr, columns="signals")
+        assert os.path.basename(out1) != os.path.basename(out2)
+
+    def test_path_none_falls_back_to_root_log_dir(self, tmp_path):
+        mgr = _make_manager()
+        mock_logger = MagicMock()
+        mock_logger.chkpt_manager.root_log_dir = tmp_path
+        with patch("weightslab.src.get_dataframe", return_value=mgr), \
+             patch("weightslab.src.get_logger", return_value=mock_logger):
+            out = write_dataframe()
+        assert os.path.isfile(out)
+        assert os.path.dirname(os.path.abspath(out)) == str(tmp_path.resolve())
+
+    def test_path_none_no_logger_falls_back_to_cwd(self):
+        mgr = _make_manager()
+        with patch("weightslab.src.get_dataframe", return_value=mgr), \
+             patch("weightslab.src.get_logger", return_value=None):
+            out = write_dataframe()
+        assert os.path.isfile(out)
+        os.remove(out)
+
+    def test_unsupported_format_raises(self, mgr, tmp_json):
+        with pytest.raises(ValueError, match="unsupported format"):
+            _call(tmp_json.replace(".json", ".parquet"), mgr, format="parquet")
+
+
+# ---------------------------------------------------------------------------
+# No dataframe manager
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframeNoManager:
+    def test_returns_path_when_no_manager(self, tmp_json):
+        with patch("weightslab.src.get_dataframe", return_value=None), \
+             patch("weightslab.src.get_logger", return_value=None):
+            result = write_dataframe(tmp_json)
+        assert result == tmp_json
+        assert not os.path.isfile(tmp_json)  # nothing written
+
+
+# ---------------------------------------------------------------------------
+# Column group filters
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframeColumnFilters:
+    def test_columns_all_keeps_everything(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns="all")
+        data = json.loads(open(tmp_json).read())
+        assert "signals_loss" in data[0] or any("signals_loss" in r for r in data)
+
+    def test_columns_tags_only(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns="tags")
+        data = json.loads(open(tmp_json).read())
+        non_index = [k for k in data[0] if k not in ("sample_id", "annotation_id")]
+        assert all(k.startswith("tag:") or k.startswith("TAG:") for k in non_index)
+
+    def test_columns_signals_only(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns="signals")
+        data = json.loads(open(tmp_json).read())
+        non_index = [k for k in data[0] if k not in ("sample_id", "annotation_id")]
+        assert all(str(k).lower().startswith("signals") for k in non_index)
+
+    def test_columns_discarded_only(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns="discarded")
+        data = json.loads(open(tmp_json).read())
+        non_index = [k for k in data[0] if k not in ("sample_id", "annotation_id")]
+        assert non_index == ["discarded"]
+
+    def test_columns_list_of_groups(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns=["tags", "discarded"])
+        data = json.loads(open(tmp_json).read())
+        non_index = set(k for r in data for k in r if k not in ("sample_id", "annotation_id"))
+        assert "discarded" in non_index
+        assert any(k.startswith("tag:") for k in non_index)
+        assert not any(str(k).lower().startswith("signals") for k in non_index)
+
+    def test_columns_exact_name(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns=["signals_loss"])
+        data = json.loads(open(tmp_json).read())
+        non_index = [k for k in data[0] if k not in ("sample_id", "annotation_id")]
+        assert non_index == ["signals_loss"]
+
+    def test_columns_nonexistent_name_yields_empty_cols(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns=["nonexistent_col"])
+        data = json.loads(open(tmp_json).read())
+        # Index columns always present; no extra columns
+        for row in data:
+            assert set(row.keys()) <= {"sample_id", "annotation_id"}
+
+    def test_columns_none_keeps_all(self, mgr, tmp_json):
+        _call(tmp_json, mgr, columns=None)
+        data = json.loads(open(tmp_json).read())
+        assert "signals_loss" in data[0] or any("signals_loss" in r for r in data)
+
+
+# ---------------------------------------------------------------------------
+# Index-level filters
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframeIndexFilters:
+    def test_sample_id_single(self, mgr, tmp_json):
+        _call(tmp_json, mgr, sample_id="s1")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["sample_id"] == "s1" for r in data)
+        assert len(data) == 2  # s1 has annotation_ids 0 and 1
+
+    def test_sample_id_list(self, mgr, tmp_json):
+        _call(tmp_json, mgr, sample_id=["s1", "s2"])
+        data = json.loads(open(tmp_json).read())
+        sids = {r["sample_id"] for r in data}
+        assert sids == {"s1", "s2"}
+        assert len(data) == 4
+
+    def test_instance_id_zero_keeps_sample_rows(self, mgr, tmp_json):
+        _call(tmp_json, mgr, instance_id=0)
+        data = json.loads(open(tmp_json).read())
+        assert all(r["annotation_id"] == 0 for r in data)
+        assert len(data) == 2  # s1 and s2 both have annotation_id=0
+
+    def test_instance_id_list(self, mgr, tmp_json):
+        _call(tmp_json, mgr, instance_id=[1, 2])
+        data = json.loads(open(tmp_json).read())
+        assert all(r["annotation_id"] in (1, 2) for r in data)
+
+    def test_sample_and_instance_combined(self, mgr, tmp_json):
+        _call(tmp_json, mgr, sample_id="s1", instance_id=1)
+        data = json.loads(open(tmp_json).read())
+        assert len(data) == 1
+        assert data[0]["sample_id"] == "s1"
+        assert data[0]["annotation_id"] == 1
+
+    def test_empty_result_when_no_match(self, mgr, tmp_json):
+        _call(tmp_json, mgr, sample_id="nonexistent")
+        data = json.loads(open(tmp_json).read())
+        assert data == []
+
+
+# ---------------------------------------------------------------------------
+# Empty dataframe
+# ---------------------------------------------------------------------------
+
+class TestWriteDataframeEmpty:
+    def test_empty_df_writes_empty_json(self, tmp_json):
+        mgr = _make_manager(df=pd.DataFrame())
+        _call(tmp_json, mgr)
+        data = json.loads(open(tmp_json).read())
+        assert data == []
+
+    def test_empty_df_writes_empty_csv(self, tmp_csv):
+        mgr = _make_manager(df=pd.DataFrame())
+        _call(tmp_csv, mgr, format="csv")
+        assert os.path.isfile(tmp_csv)

--- a/weightslab/tests/backend/test_write_dataframe.py
+++ b/weightslab/tests/backend/test_write_dataframe.py
@@ -2,7 +2,7 @@
 import csv
 import json
 import os
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -119,7 +119,6 @@ class TestWriteDataframeCsvStructure:
         _call(tmp_csv, mgr, format="csv")
         with open(tmp_csv) as fh:
             reader = csv.DictReader(fh)
-            rows = list(reader)
         assert "sample_id" in reader.fieldnames
         assert "annotation_id" in reader.fieldnames
 

--- a/weightslab/tests/backend/test_write_history.py
+++ b/weightslab/tests/backend/test_write_history.py
@@ -1,0 +1,552 @@
+"""Tests for wl.write_history — JSON/CSV dump of signal history with filtering."""
+import csv
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from weightslab.backend.logger import LoggerQueue
+from weightslab.src import write_history
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_chkpt(hash_val):
+    m = MagicMock()
+    m.get_current_experiment_hash.return_value = hash_val
+    return m
+
+
+def _make_logger():
+    """Return a fresh LoggerQueue with data under two hashes.
+
+    h1: loss (steps 1+2), acc (step 1), iou instances (annotation_ids 1,2)
+    h2: loss (step 1), acc (step 1), iou instance (annotation_id 3)  ← current hash
+    """
+    lg = LoggerQueue(register=False)
+    ckpt = _mock_chkpt("h1")
+    lg.chkpt_manager = ckpt
+
+    # h1 data
+    lg.add_scalars("loss", {"loss": 1.0}, 1, signal_per_sample={"s1": 1.0}, aggregate_by_step=False)
+    lg.add_scalars("loss", {"loss": 2.0}, 2, signal_per_sample={"s2": 2.0}, aggregate_by_step=False)
+    lg.add_scalars("acc",  {"acc":  0.9}, 1, signal_per_sample={"s1": 0.9}, aggregate_by_step=False)
+    lg.add_instance_scalars("iou", sample_ids=["s1"], annotation_ids=[1],
+                             values=[0.8], global_step=1, exp_hash="h1")
+    lg.add_instance_scalars("iou", sample_ids=["s2"], annotation_ids=[2],
+                             values=[0.6], global_step=1, exp_hash="h1")
+
+    # h2 data — left as the "current" hash after setup
+    ckpt.get_current_experiment_hash.return_value = "h2"
+    lg.add_scalars("loss", {"loss": 3.0}, 1, signal_per_sample={"s1": 3.0}, aggregate_by_step=False)
+    lg.add_scalars("acc",  {"acc":  0.7}, 1, signal_per_sample={"s2": 0.7}, aggregate_by_step=False)
+    lg.add_instance_scalars("iou", sample_ids=["s1"], annotation_ids=[3],
+                             values=[0.7], global_step=1, exp_hash="h2")
+
+    return lg
+
+
+def _call(path, lg_instance, **kwargs):
+    with patch("weightslab.src.get_logger", return_value=lg_instance):
+        return write_history(path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def lg():
+    return _make_logger()
+
+
+@pytest.fixture()
+def tmp_json(tmp_path):
+    return str(tmp_path / "out.json")
+
+
+@pytest.fixture()
+def tmp_csv(tmp_path):
+    return str(tmp_path / "out.csv")
+
+
+# ---------------------------------------------------------------------------
+# JSON — structure
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryJsonStructure:
+    def test_json_has_all_sections(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"global", "sample", "instance"}
+
+    def test_global_section_not_empty(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        data = json.loads(open(tmp_json).read())
+        assert len(data["global"]) > 0
+
+    def test_sample_section_not_empty(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        data = json.loads(open(tmp_json).read())
+        assert len(data["sample"]) > 0
+
+    def test_instance_section_not_empty(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        data = json.loads(open(tmp_json).read())
+        assert len(data["instance"]) > 0
+
+    def test_global_row_keys(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        row = json.loads(open(tmp_json).read())["global"][0]
+        assert {"graph_name", "experiment_hash", "step", "metric_value"} <= set(row.keys())
+
+    def test_sample_row_keys(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        row = json.loads(open(tmp_json).read())["sample"][0]
+        assert {"graph_name", "experiment_hash", "sample_id", "step", "metric_value"} <= set(row.keys())
+
+    def test_instance_row_keys(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        row = json.loads(open(tmp_json).read())["instance"][0]
+        assert {
+            "graph_name", "experiment_hash", "sample_id", "annotation_id", "step", "metric_value"
+        } <= set(row.keys())
+
+    def test_file_is_valid_json(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        json.loads(open(tmp_json).read())  # must not raise
+
+    def test_output_file_created(self, lg, tmp_json):
+        _call(tmp_json, lg)
+        assert os.path.exists(tmp_json)
+
+
+# ---------------------------------------------------------------------------
+# JSON — type_of_history filtering
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryJsonTypeFilter:
+    def test_type_all_explicit(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="all")
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"global", "sample", "instance"}
+
+    def test_type_none_means_all(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history=None)
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"global", "sample", "instance"}
+
+    def test_type_global_only(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global")
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"global"}
+        assert "sample" not in data
+        assert "instance" not in data
+
+    def test_type_sample_only(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="sample")
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"sample"}
+        assert "global" not in data
+        assert "instance" not in data
+
+    def test_type_instance_only(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance")
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"instance"}
+        assert "global" not in data
+        assert "sample" not in data
+
+    def test_type_instances_plural_alias(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instances")
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"instance"}
+
+
+# ---------------------------------------------------------------------------
+# JSON — graph_name filtering
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryJsonGraphFilter:
+    def test_graph_name_filters_global(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["graph_name"] == "loss" for r in data["global"])
+
+    def test_graph_name_filters_sample(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="sample", graph_name="acc")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["graph_name"] == "acc" for r in data["sample"])
+
+    def test_graph_name_filters_instance(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance", graph_name="iou")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["graph_name"] == "iou" for r in data["instance"])
+
+    def test_unknown_graph_name_global_empty(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name="no_such_graph")
+        data = json.loads(open(tmp_json).read())
+        assert data["global"] == []
+
+    def test_unknown_graph_name_sample_empty(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="sample", graph_name="no_such_graph")
+        data = json.loads(open(tmp_json).read())
+        assert data["sample"] == []
+
+    def test_multiple_graphs_all_present_without_filter(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global")
+        data = json.loads(open(tmp_json).read())
+        graph_names = {r["graph_name"] for r in data["global"]}
+        assert "loss" in graph_names and "acc" in graph_names
+
+
+# ---------------------------------------------------------------------------
+# JSON — experiment_hash filtering
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryJsonHashFilter:
+    def test_exp_hash_filters_global(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", experiment_hash="h1")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["experiment_hash"] == "h1" for r in data["global"])
+
+    def test_exp_hash_filters_sample(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="sample", experiment_hash="h2")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["experiment_hash"] == "h2" for r in data["sample"])
+        assert len(data["sample"]) > 0
+
+    def test_exp_hash_missing_global_empty(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", experiment_hash="hX")
+        data = json.loads(open(tmp_json).read())
+        assert data["global"] == []
+
+    def test_exp_hash_filters_instance(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance", experiment_hash="h1")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["experiment_hash"] == "h1" for r in data["instance"])
+
+    def test_both_hashes_present_with_all(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss", experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        hashes = {r["experiment_hash"] for r in data["global"]}
+        assert "h1" in hashes and "h2" in hashes
+
+
+# ---------------------------------------------------------------------------
+# JSON — sample_id / instance_id filtering
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryJsonSampleFilter:
+    def test_sample_id_filters_sample_history(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="sample", graph_name="loss", sample_id="s1")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["sample_id"] == "s1" for r in data["sample"])
+
+    def test_sample_id_filters_instance_history(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance", sample_id="s1")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["sample_id"] == "s1" for r in data["instance"])
+
+    def test_instance_id_filters_instance_history(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance", instance_id=1)
+        data = json.loads(open(tmp_json).read())
+        assert all(r["annotation_id"] == 1 for r in data["instance"])
+
+    def test_sample_and_instance_id_combined(self, lg, tmp_json):
+        # annotation_id=1 lives under h1
+        _call(tmp_json, lg, type_of_history="instance", sample_id="s1",
+              instance_id=1, experiment_hash="h1")
+        data = json.loads(open(tmp_json).read())
+        assert len(data["instance"]) == 1
+        assert data["instance"][0]["sample_id"] == "s1"
+        assert data["instance"][0]["annotation_id"] == 1
+
+    def test_sample_id_no_effect_on_global(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss",
+              sample_id="s1", experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        hashes = {r["experiment_hash"] for r in data["global"]}
+        assert "h1" in hashes and "h2" in hashes
+
+
+# ---------------------------------------------------------------------------
+# JSON — values correctness
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryJsonValues:
+    def test_global_steps_present(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss", experiment_hash="h1")
+        data = json.loads(open(tmp_json).read())
+        steps = {r["step"] for r in data["global"]}
+        assert 1 in steps and 2 in steps
+
+    def test_sample_value_correct(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="sample", graph_name="loss",
+              experiment_hash="h1", sample_id="s1")
+        data = json.loads(open(tmp_json).read())
+        assert len(data["sample"]) == 1
+        assert abs(data["sample"][0]["metric_value"] - 1.0) < 1e-5
+
+    def test_instance_value_correct(self, lg, tmp_json):
+        # value 0.8 for annotation_id=1 is stored under h1
+        _call(tmp_json, lg, type_of_history="instance", graph_name="iou",
+              sample_id="s1", instance_id=1, experiment_hash="h1")
+        data = json.loads(open(tmp_json).read())
+        assert abs(data["instance"][0]["metric_value"] - 0.8) < 1e-4
+
+    def test_combined_graph_hash_filter(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss", experiment_hash="h2")
+        data = json.loads(open(tmp_json).read())
+        for row in data["global"]:
+            assert row["graph_name"] == "loss"
+            assert row["experiment_hash"] == "h2"
+
+
+# ---------------------------------------------------------------------------
+# CSV — structure
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryCSVStructure:
+    def _rows(self, path):
+        with open(path, newline="", encoding="utf-8") as fh:
+            return list(csv.DictReader(fh))
+
+    def test_csv_header_columns(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv")
+        with open(tmp_csv, newline="", encoding="utf-8") as fh:
+            header = next(csv.reader(fh))
+        expected = {"type", "graph_name", "experiment_hash", "step", "metric_value",
+                    "sample_id", "annotation_id"}
+        assert expected <= set(header)
+
+    def test_csv_has_global_rows(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv")
+        rows = self._rows(tmp_csv)
+        assert any(r["type"] == "global" for r in rows)
+
+    def test_csv_has_sample_rows(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv")
+        rows = self._rows(tmp_csv)
+        assert any(r["type"] == "sample" for r in rows)
+
+    def test_csv_has_instance_rows(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv")
+        rows = self._rows(tmp_csv)
+        assert any(r["type"] == "instance" for r in rows)
+
+    def test_csv_type_sample_only(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv", type_of_history="sample")
+        rows = self._rows(tmp_csv)
+        assert all(r["type"] == "sample" for r in rows)
+
+    def test_csv_type_instance_only(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv", type_of_history="instance")
+        rows = self._rows(tmp_csv)
+        assert all(r["type"] == "instance" for r in rows)
+
+    def test_csv_graph_name_filter(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv", graph_name="loss")
+        rows = self._rows(tmp_csv)
+        assert all(r["graph_name"] == "loss" for r in rows)
+
+    def test_csv_sample_id_filter(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv", type_of_history="sample", sample_id="s2")
+        rows = self._rows(tmp_csv)
+        assert all(r["sample_id"] == "s2" for r in rows)
+
+    def test_csv_file_created(self, lg, tmp_csv):
+        _call(tmp_csv, lg, format="csv")
+        assert os.path.exists(tmp_csv)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestWriteHistoryEdgeCases:
+    def test_no_logger_returns_without_creating_file(self, tmp_path):
+        out = str(tmp_path / "out.json")
+        with patch("weightslab.src.get_logger", return_value=None):
+            write_history(out)
+        assert not os.path.exists(out)
+
+    def test_invalid_format_raises(self, lg, tmp_json):
+        with pytest.raises(ValueError, match="unsupported format"):
+            _call(tmp_json, lg, format="xlsx")
+
+    def test_empty_logger_writes_empty_sections_json(self, tmp_json):
+        empty_lg = LoggerQueue(register=False)
+        empty_lg.chkpt_manager = None
+        with patch("weightslab.src.get_logger", return_value=empty_lg):
+            write_history(tmp_json, experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        assert data["global"] == []
+        assert data["sample"] == []
+        assert data["instance"] == []
+
+    def test_empty_logger_writes_header_only_csv(self, tmp_csv):
+        empty_lg = LoggerQueue(register=False)
+        empty_lg.chkpt_manager = None
+        with patch("weightslab.src.get_logger", return_value=empty_lg):
+            write_history(tmp_csv, format="csv", experiment_hash="all")
+        with open(tmp_csv, newline="", encoding="utf-8") as fh:
+            rows = list(csv.reader(fh))
+        assert len(rows) == 1  # header only
+
+    def test_case_insensitive_type(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="SAMPLE")
+        data = json.loads(open(tmp_json).read())
+        assert set(data.keys()) == {"sample"}
+
+    def test_case_insensitive_format(self, lg, tmp_json):
+        _call(tmp_json, lg, format="JSON")
+        data = json.loads(open(tmp_json).read())
+        assert "global" in data
+
+    def test_returns_written_path(self, lg, tmp_json):
+        result = _call(tmp_json, lg)
+        assert result == tmp_json
+
+    def test_directory_path_auto_generates_filename(self, lg, tmp_path):
+        import re
+        dirpath = str(tmp_path / "outdir")
+        with patch("weightslab.src.get_logger", return_value=lg):
+            out = write_history(dirpath)
+        assert os.path.isfile(out)
+        assert out.endswith(".json")
+        # filename should be <8-char hex hash>_history.json
+        assert re.match(r"[0-9a-f]{8}_history\.json$", os.path.basename(out))
+
+    def test_directory_path_same_params_same_filename(self, lg, tmp_path):
+        """Same call parameters always produce the same filename (deterministic hash)."""
+        dirpath = str(tmp_path / "outdir")
+        with patch("weightslab.src.get_logger", return_value=lg):
+            out1 = write_history(dirpath, type_of_history="global", graph_name="loss",
+                                 experiment_hash="all")
+            out2 = write_history(dirpath, type_of_history="global", graph_name="loss",
+                                 experiment_hash="all")
+        assert os.path.basename(out1) == os.path.basename(out2)
+
+    def test_directory_path_different_params_different_filename(self, lg, tmp_path):
+        """Different filter params produce different filenames."""
+        dirpath = str(tmp_path / "outdir")
+        with patch("weightslab.src.get_logger", return_value=lg):
+            out_a = write_history(dirpath, type_of_history="global", experiment_hash="all")
+            out_b = write_history(dirpath, type_of_history="sample", experiment_hash="all")
+        assert os.path.basename(out_a) != os.path.basename(out_b)
+
+    def test_directory_is_created_if_missing(self, lg, tmp_path):
+        dirpath = str(tmp_path / "new" / "nested" / "dir")
+        with patch("weightslab.src.get_logger", return_value=lg):
+            out = write_history(dirpath)
+        assert os.path.isfile(out)
+
+    def test_directory_path_csv_format(self, lg, tmp_path):
+        import re
+        dirpath = str(tmp_path / "outdir")
+        with patch("weightslab.src.get_logger", return_value=lg):
+            out = write_history(dirpath, format="csv")
+        assert out.endswith(".csv")
+        assert re.match(r"[0-9a-f]{8}_history\.csv$", os.path.basename(out))
+
+    def test_graph_name_list_filters_global(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name=["loss", "acc"])
+        data = json.loads(open(tmp_json).read())
+        assert all(r["graph_name"] in {"loss", "acc"} for r in data["global"])
+        names = {r["graph_name"] for r in data["global"]}
+        assert "loss" in names and "acc" in names
+
+    def test_graph_name_list_filters_sample(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="sample", graph_name=["loss", "acc"])
+        data = json.loads(open(tmp_json).read())
+        names = {r["graph_name"] for r in data["sample"]}
+        assert "loss" in names and "acc" in names
+
+    def test_sample_id_list_filters_sample(self, lg, tmp_json):
+        # s2 for "loss" is under h1 only; use "all" to see both hashes
+        _call(tmp_json, lg, type_of_history="sample", graph_name="loss",
+              sample_id=["s1", "s2"], experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        sids = {r["sample_id"] for r in data["sample"]}
+        assert sids == {"s1", "s2"}
+
+    def test_sample_id_list_filters_instance(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance", sample_id=["s1", "s2"],
+              experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        sids = {r["sample_id"] for r in data["instance"]}
+        assert sids == {"s1", "s2"}
+
+    def test_instance_id_list_filters_instance(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance", instance_id=[1, 2],
+              experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        aids = {r["annotation_id"] for r in data["instance"]}
+        assert aids == {1, 2}
+
+    def test_instance_id_list_single_value(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="instance", instance_id=[1],
+              experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        assert all(r["annotation_id"] == 1 for r in data["instance"])
+
+    # -- new: experiment_hash default / "all" behavior --
+
+    def test_default_hash_uses_current(self, lg, tmp_json):
+        # current hash is h2; without specifying, only h2 rows returned
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss")
+        data = json.loads(open(tmp_json).read())
+        hashes = {r["experiment_hash"] for r in data["global"]}
+        assert hashes == {"h2"}
+
+    def test_experiment_hash_all_returns_every_hash(self, lg, tmp_json):
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss",
+              experiment_hash="all")
+        data = json.loads(open(tmp_json).read())
+        hashes = {r["experiment_hash"] for r in data["global"]}
+        assert "h1" in hashes and "h2" in hashes
+
+    def test_explicit_hash_overrides_current(self, lg, tmp_json):
+        # pass h1 explicitly even though current is h2
+        _call(tmp_json, lg, type_of_history="global", graph_name="loss",
+              experiment_hash="h1")
+        data = json.loads(open(tmp_json).read())
+        hashes = {r["experiment_hash"] for r in data["global"]}
+        assert hashes == {"h1"}
+
+    def test_default_hash_no_chkpt_manager_returns_none_key(self, tmp_json):
+        # logger with no chkpt_manager: current hash = None → stored under None key
+        lg = LoggerQueue(register=False)
+        lg.chkpt_manager = None
+        lg.add_scalars("loss", {"loss": 0.5}, 1,
+                       signal_per_sample=None, aggregate_by_step=False)
+        with patch("weightslab.src.get_logger", return_value=lg):
+            write_history(tmp_json, type_of_history="global")
+        data = json.loads(open(tmp_json).read())
+        # row exists (experiment_hash stored as "")
+        assert len(data["global"]) == 1
+        assert data["global"][0]["experiment_hash"] == ""
+
+    def test_path_none_uses_root_log_dir(self, lg, tmp_path):
+        """path=None falls back to chkpt_manager.root_log_dir."""
+        lg.chkpt_manager.root_log_dir = tmp_path
+        with patch("weightslab.src.get_logger", return_value=lg):
+            out = write_history()
+        assert os.path.isfile(out)
+        assert os.path.dirname(os.path.abspath(out)) == str(tmp_path.resolve())
+
+    def test_path_none_no_chkpt_manager_falls_back_to_cwd(self):
+        """path=None with no checkpoint manager writes into current directory."""
+        lg = LoggerQueue(register=False)
+        lg.chkpt_manager = None
+        lg.add_scalars("loss", {"loss": 0.1}, 1,
+                       signal_per_sample=None, aggregate_by_step=False)
+        with patch("weightslab.src.get_logger", return_value=lg):
+            out = write_history()
+        assert os.path.isfile(out)
+        # clean up
+        os.remove(out)

--- a/weightslab/tests/components/test_checkpoint_workflow.py
+++ b/weightslab/tests/components/test_checkpoint_workflow.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from weightslab.components.checkpoint_manager import CheckpointManager
 from weightslab.components.experiment_hash import ExperimentHashGenerator
 from weightslab.data.sample_stats import SampleStatsEx
-from weightslab.utils.logger import LoggerQueue
+from weightslab.backend.logger import LoggerQueue
 from weightslab.backend import ledgers
 from weightslab.components.global_monitoring import (
     guard_training_context,

--- a/weightslab/tests/general/test_logger_snapshot_rotation.py
+++ b/weightslab/tests/general/test_logger_snapshot_rotation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from weightslab.backend import ledgers
 from weightslab.components.checkpoint_manager import CheckpointManager
-from weightslab.utils.logger import LoggerQueue
+from weightslab.backend.logger import LoggerQueue
 
 
 class LoggerSnapshotRotationTests(unittest.TestCase):

--- a/weightslab/tests/model/test_logger.py
+++ b/weightslab/tests/model/test_logger.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import torch as th
 
-from weightslab.utils.logger import LoggerQueue
+from weightslab.backend.logger import LoggerQueue
 from weightslab.src import _log_signal
 
 
@@ -13,7 +13,7 @@ class TestLoggerQueue(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-cnn-001"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             logger = LoggerQueue(register=False)
 
         class TinyCNN(th.nn.Module):
@@ -127,7 +127,7 @@ class TestLoggerQueue(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-hash-123"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             logger = LoggerQueue(register=False)
 
         logger.add_scalars(
@@ -176,7 +176,7 @@ class TestLoggerQueue(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-hash-agg"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             logger = LoggerQueue(register=False)
 
         logger.add_scalars(
@@ -222,7 +222,7 @@ class TestLoggerQueue(unittest.TestCase):
         )
 
     def test_get_and_clear_queue_returns_incremental_items(self):
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=None):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=None):
             logger = LoggerQueue(register=False)
 
         logger.add_scalars("acc", {"acc": 0.7}, global_step=1, signal_per_sample={1: 0.7}, aggregate_by_step=False)
@@ -236,7 +236,7 @@ class TestLoggerQueue(unittest.TestCase):
         self.assertEqual(logger.get_and_clear_queue(), [])
 
     def test_load_snapshot_restores_graph_and_histories(self):
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=None):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=None):
             logger = LoggerQueue(register=False)
 
         snapshot = {
@@ -278,7 +278,7 @@ class TestLoggerQueue(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-hash-xyz"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             logger = LoggerQueue(register=False)
 
         logger.add_scalars(
@@ -297,7 +297,7 @@ class TestLoggerQueue(unittest.TestCase):
         self.assertIn(3, snapshot["signal_history"]["accuracy"]["exp-hash-xyz"])
 
     def test_clear_signal_histories_keeps_graph_names(self):
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=None):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=None):
             logger = LoggerQueue(register=False)
 
         logger.graph_names.update({"loss"})
@@ -371,7 +371,7 @@ class TestLoggerQueueEvaluationMetadata(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-base-001"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             logger = LoggerQueue(register=False)
 
         logger.start_evaluation_mode("train_loader", "exp-base-001_1", evaluation_tags=["EvalSubset", "priority"])
@@ -400,7 +400,7 @@ class TestLoggerQueueEvaluationMetadata(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-note-001"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             logger = LoggerQueue(register=False)
 
         logger.add_scalars(
@@ -429,7 +429,7 @@ class TestLoggerQueueEvaluationMetadata(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-audit-001"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             with patch("weightslab.backend.ledgers.get_hyperparams", return_value={"auditor_mode": True}):
                 logger = LoggerQueue(register=False)
 
@@ -459,7 +459,7 @@ class TestLoggerQueueEvaluationMetadata(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-normal-001"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             with patch("weightslab.backend.ledgers.get_hyperparams", return_value={"auditor_mode": False}):
                 logger = LoggerQueue(register=False)
 
@@ -480,7 +480,7 @@ class TestLoggerQueueEvaluationMetadata(unittest.TestCase):
         chkpt = MagicMock()
         chkpt.get_current_experiment_hash.return_value = "exp-eval-001"
 
-        with patch("weightslab.utils.logger.get_checkpoint_manager", return_value=chkpt):
+        with patch("weightslab.backend.logger.get_checkpoint_manager", return_value=chkpt):
             with patch("weightslab.backend.ledgers.get_hyperparams", return_value={"auditor_mode": True}):
                 logger = LoggerQueue(register=False)
 

--- a/weightslab/trainer/services/experiment_service.py
+++ b/weightslab/trainer/services/experiment_service.py
@@ -225,25 +225,14 @@ class ExperimentService(pb2_grpc.ExperimentServiceServicer):
             now = int(time.time())
             eval_hashes = set(signal_logger.get_evaluation_marker_hashes())
 
-            # AGGREGATE the per-sample curves into a single MEAN curve per
-            # experiment_hash, computed here in the backend. Instead of streaming one
-            # curve per sample (10k samples × 10k steps → 100M points), we send the
-            # mean over the matching samples at each step → one curve per run. We
-            # accumulate sum/count per (exp_hash, step) in a single pass (O(points),
-            # no per-sample buffering), then emit mean = sum / count.
-            from collections import defaultdict
-            sums = defaultdict(float)
-            counts = defaultdict(int)
-            for sid, step, val, exp_hash in signal_logger.query_per_sample(
-                    graph_name, sample_ids=sample_ids):
-                key = (exp_hash if exp_hash else "N.A.", int(step))
-                sums[key] += float(val)
-                counts[key] += 1
-
-            # Regroup the (exp_hash, step) means into one step-ordered series per hash.
-            per_hash = defaultdict(list)
-            for (exp_hash, step), total in sums.items():
-                per_hash[exp_hash].append((step, total / counts[(exp_hash, step)]))
+            # AGGREGATE: numpy-vectorized mean per (exp_hash, step) over matching samples.
+            # aggregate_per_sample_by_step uses np.unique + np.bincount — ~100× faster
+            # than a Python loop for large sample counts.
+            per_hash = signal_logger.aggregate_per_sample_by_step(
+                graph_name, sample_ids=sample_ids
+            )
+            # Normalise None keys that come from experiments with no hash
+            per_hash = {(h if h is not None else "N.A."): v for h, v in per_hash.items()}
 
             # Still cap each returned curve's length (a run can have 10k+ steps);
             # WL_MAX_POINTS_PER_SAMPLE bounds points per returned curve (endpoints kept).


### PR DESCRIPTION
- Add to logger history per instance
- Add new logger functions and tests
- Add a user function to write history to a path with filters as json or tabular data (csv): wl.write_history
- Add a user function to write the df view to a path with filters as json or tabular data (csv): wl.write_dataframe 
- Add and fix new utests
- Update detection example with those functions and the custom signals function also
