### PR TITLE
Fix CI lint: drop unused ledgers import + duplicate torchvision import

### DIFF
--- a/weightslab/examples/PyTorch/ws-classification/main.py
+++ b/weightslab/examples/PyTorch/ws-classification/main.py
@@ -20,11 +20,9 @@ import torch.optim as optim
 
 from torchvision import datasets, transforms
 from torchmetrics.classification import Accuracy
-from torchvision import datasets, transforms
 from torch.utils.data import Dataset
 
 import weightslab as wl
-from weightslab.backend import ledgers
 from weightslab.baseline_models.pytorch.models import FashionCNN as CNN
 from weightslab.components.global_monitoring import (
     guard_training_context,


### PR DESCRIPTION
## What
Fixes the ruff `F401` that currently fails `code-quality` CI on **every** branch (the lint job scans the whole `./weightslab` tree).

- `eca9e25` removed the `hp = ledgers.get_hyperparams()` call in `ws-classification/main.py` but left `from weightslab.backend import ledgers` → unused import (`F401`).
- Also drops the exact-duplicate `from torchvision import datasets, transforms` line (`F811`). Both `datasets` and `transforms` remain used.

Two-line change; unblocks CI for all open PRs (e.g. #221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)