### PR TITLE
fix(ledger): Proxy[key] returns a live value proxy like .get()

### DIFF
--- a/weightslab/backend/ledgers.py
+++ b/weightslab/backend/ledgers.py
@@ -582,7 +582,19 @@ class Proxy:
     def __getitem__(self, idx):
         if self._obj is None:
             raise TypeError("Proxy target not set")
-        return self._obj[idx]
+        value = self._obj[idx]
+        # Mirror .get(): subscript access on a mapping returns a live key proxy
+        # for "simple" values, so ``b['test']`` tracks studio edits exactly like
+        # ``b.get('test')``. Lists/slices and non-mapping containers, plus
+        # list/dict/callable values, are returned raw (unchanged behavior).
+        if (hasattr(self._obj, "get") and hasattr(self._obj, "keys")
+                and not (isinstance(value, (list, dict)) or callable(value))):
+            vp = Proxy._ValueProxy(self, idx)
+            # str / torch.device are handed back plain (see _plain_get_value);
+            # other simple types stay live proxies so studio edits keep tracking.
+            plain = _plain_get_value(vp._resolve())
+            return vp if plain is _KEEP_AS_PROXY else plain
+        return value
 
     def __setitem__(self, key, value):
         """Support item assignment: proxy[key] = value"""


### PR DESCRIPTION
Proxy.__getitem__ returned the raw value while Proxy.get() returned a live _ValueProxy. Mirror .get() for mapping subscript access so both `b.get('test')` and `b['test']` return a tracking proxy for simple values.

Scoped to mapping access (object has .get + keys); list/slice indexing and list/dict/callable values are returned raw as before. str/torch.device stay plain via _plain_get_value.