### PR TITLE
Support multi-root experiment directories in CheckpointManager

### DIFF
--- a/docs/checkpointing.rst
+++ b/docs/checkpointing.rst
@@ -1,0 +1,239 @@
+Checkpointing and Experiment Versioning
+========================================
+
+WeightsLab versions an experiment by content, not by filename. Every time the
+model, hyperparameters, or data state changes, ``CheckpointManager`` computes a
+new **experiment hash** and checkpoints under it — so resuming, branching from
+an earlier state, and reproducing a run are all the same mechanism: load the
+hash you want.
+
+Directory structure
+--------------------
+
+``CheckpointManager(root_log_dir=...)`` lays out everything under one root:
+
+.. code-block:: text
+
+   root_log_dir/
+       checkpoints/
+           manifest.yaml          # hash chronology: created/last_used, latest_weight_checkpoint
+           models/
+               <model_hash>/
+                   <hash>_step_000100.pt
+                   <hash>_architecture.pkl        # only if dump_model_architecture=True
+           HP/
+               <hp_hash>/
+                   <hp_hash>_config.yaml
+           data/
+               <data_hash>/
+                   <data_hash>_data_snapshot.json  # metadata + RNG state
+                   <data_hash>_data_snapshot.parquet
+           loggers/
+               loggers.duckdb      # on-disk signal-history database
+
+``root_log_dir`` comes from the top-level ``root_log_dir`` key in your
+hyperparameters config (or the ``root_log_dir=`` kwarg on
+``wl.watch_or_edit(..., flag="model"/"data"/...)`` for a per-object override)
+— see :doc:`configuration`.
+
+The experiment hash
+--------------------
+
+The **24-byte combined hash** is three 8-byte segments concatenated:
+
+.. code-block:: text
+
+   HP(8) + MODEL(8) + DATA(8) = 24-byte experiment hash
+
+- **HP** — hyperparameters snapshot (everything in the registered config).
+- **MODEL** — model architecture + the step it was initialized at.
+- **DATA** — per-sample tags and discard state.
+
+Each segment is also used as a directory name on its own (``models/<model_hash>/``,
+``HP/<hp_hash>/``, ``data/<data_hash>/``), so unrelated experiments that happen
+to share, say, the same model architecture reuse that one architecture file
+instead of duplicating it.
+
+Changing only the data state (tagging/discarding samples) changes the DATA
+segment and produces a new combined hash, while HP and MODEL segments stay the
+same — so the model directory is reused and only a new data/weights
+checkpoint is written. The same applies to changing only hyperparameters or
+only the model.
+
+Pending vs. immediate changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``update_experiment_hash()`` detects what changed and either:
+
+- **dumps immediately** (``dump_immediately=True``) — writes the new
+  checkpoint right away, or
+- **marks pending** — remembers what changed but defers the write until
+  ``save_pending_changes()`` is called (e.g. when training resumes after an
+  edit made while paused).
+
+This avoids writing a checkpoint for every intermediate edit while the UI or
+an agent is actively reshaping hyperparameters/data before resuming training.
+
+The manifest and auto-resume
+------------------------------
+
+``checkpoints/manifest.yaml`` tracks every experiment hash ever seen under
+that root, with ``created``/``last_used`` timestamps, the ``latest_hash``, and
+each hash's ``latest_weight_checkpoint``/``latest_weight_step``. Constructing
+``CheckpointManager(root_log_dir=...)`` on an **existing** root automatically
+resumes the latest hash — no explicit ``load_state()`` call needed:
+
+.. code-block:: python
+
+   from weightslab.components.checkpoint_manager import CheckpointManager
+
+   # If root_log_dir already has checkpoints, this resumes the latest one.
+   manager = CheckpointManager(root_log_dir="./logs/my_experiment")
+
+Branching from an older state
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because every state is addressed by its hash, "branching" is just loading an
+older hash and continuing training — the next change produces a new hash
+alongside (not replacing) the branch point:
+
+.. code-block:: python
+
+   manager.load_state(older_hash, force=True)
+   # ... continue training; the next change creates a new hash that
+   # descends from older_hash, leaving the original branch on disk intact.
+
+Step-aware checkpoint selection
+---------------------------------
+
+Within one experiment hash, multiple weight checkpoints accumulate at
+different training steps (``<hash>_step_000100.pt``, ``..._step_000200.pt``,
+...). ``load_checkpoint(exp_hash, target_step=...)`` picks the checkpoint
+closest to ``target_step`` (ties break toward the higher step); omit
+``target_step`` to get the latest one.
+
+Reproducibility
+-----------------
+
+Every weight checkpoint and data snapshot also carries:
+
+- **RNG state** (Python/NumPy/Torch) — restored on load so the exact sampling
+  order resumes.
+- **Dataloader iteration state** — how far each registered dataloader had
+  progressed.
+
+so resuming a checkpoint continues training deterministically rather than
+just reloading weights.
+
+Signal-history logging
+-------------------------
+
+Training curves (losses, metrics, per-sample signals) persist to an on-disk
+DuckDB file at ``checkpoints/loggers/loggers.duckdb``, keyed by
+``(metric_name, experiment_hash, step)``. See :doc:`logger` for how signals
+get there in the first place. Because rows are namespaced by experiment hash,
+switching between branches never overwrites another branch's curves — they
+coexist in the same file and the UI/queries filter by hash.
+
+``checkpoint_manager`` config options
+----------------------------------------
+
+Pass these under the ``checkpoint_manager`` key of your hyperparameters
+config (see :doc:`configuration`) to control what gets dumped on a change:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 12 58
+
+   * - Option
+     - Default
+     - Description
+   * - ``enable_checkpoints``
+     - ``True``
+     - Master switch — set ``False`` to disable all checkpoint dumping.
+   * - ``dump_model_architecture``
+     - ``False``
+     - Pickle the full model object (structure + code), not just weights.
+       Skipped by default to keep large-model checkpoints small; when
+       skipped, a new hash whose model didn't change stores a small
+       *reference* to the hash that has the architecture instead of
+       duplicating it.
+   * - ``dump_model_state``
+     - ``True``
+     - Save the model's ``state_dict()``.
+   * - ``dump_optimizer_state``
+     - ``True``
+     - Save the optimizer's ``state_dict()`` alongside the model weights.
+   * - ``dump_data_state``
+     - ``True``
+     - Save the per-sample tag/discard snapshot.
+   * - ``dump_config_state``
+     - ``True``
+     - Save the hyperparameters YAML for this hash.
+
+.. code-block:: yaml
+
+   # hyperparameters.yaml
+   root_log_dir: ./logs/my_experiment
+   checkpoint_manager:
+     enable_checkpoints: true
+     dump_model_architecture: false
+     dump_optimizer_state: true
+
+Multi-root experiments
+--------------------------
+
+Point ``root_log_dir`` at a single experiment's own root (the common case
+above) — or at a **parent directory that fans out into several independent
+experiment roots**, e.g. sweeps or restarts each given their own
+sub-directory:
+
+.. code-block:: text
+
+   scorer_exp/
+       lr_tests/
+           v1/checkpoints/manifest.yaml
+           v2/checkpoints/manifest.yaml
+       dataShuffling_tests/
+           v1/checkpoints/manifest.yaml
+           v2/checkpoints/manifest.yaml
+
+.. code-block:: python
+
+   # Point at the parent directory directly -- no need to know in advance
+   # which sub-experiment is the freshest one.
+   manager = CheckpointManager(root_log_dir="./scorer_exp")
+
+``CheckpointManager`` recursively searches up to 3 levels of subdirectories
+below the given root for anything containing ``checkpoints/manifest.yaml``
+(so ``scorer_exp/lr_tests/v1`` — 2 levels down — is found; deeper than that
+is not). Given what it finds:
+
+- **Nothing found** (a brand-new, empty directory) — behaves exactly as
+  before: a fresh experiment is started there.
+- **One root found** (directly, or the sole nested one) — adopted as-is,
+  identical to pointing at it directly.
+- **Several roots found** — the one whose manifest was **most recently
+  updated** is adopted as the effective root: its latest model weights,
+  hyperparameters, and data state are loaded, and any further training
+  writes new checkpoints there too. It's exactly as if you had pointed
+  ``root_log_dir`` at that sub-directory directly.
+
+Regardless of how many roots are found, **signal-history curves are merged
+from every one of them** into the active logger, so training curves read as
+one continuous history across all the discovered roots (not just the winner's
+own) — useful when the sub-directories are really sequential attempts at the
+same run rather than unrelated experiments. Curves merge at the database row
+level and are namespaced by each root's own experiment hash, so this is
+purely additive: nothing is overwritten, and merging the same sibling twice
+(which can happen since a logger may be created before or after the manager)
+never duplicates rows.
+
+Introspecting a multi-root resolution:
+
+.. code-block:: python
+
+   manager.given_root_log_dir     # what you actually passed in
+   manager.root_log_dir           # the effective root that was adopted
+   manager.discovered_root_dirs   # every nested root that was found
+   manager.is_multi_root          # True when more than one root was found

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -73,7 +73,9 @@ Accepted by every ``flag`` value.
    * - ``root_log_dir``
      - ``None``
      - Override the root directory for checkpoints and logs for this
-       object only.  Defaults to ``WEIGHTSLAB_ROOT_LOG_DIR``.
+       object only.  Defaults to ``WEIGHTSLAB_ROOT_LOG_DIR``.  May also point
+       at a parent directory that fans out into several experiment roots —
+       see :doc:`checkpointing`.
    * - ``skip_previous_auto_load``
      - ``False``
      - Do not auto-restore from an existing checkpoint on startup.
@@ -264,7 +266,8 @@ Hyperparameters — ``flag="hyperparameters"``
    * - ``checkpoint_manager``
      - ``None``
      - Checkpoint-manager options dict, e.g.
-       ``{"load_config": True}``.
+       ``{"load_config": True}``. Full option reference and versioning
+       behavior: :doc:`checkpointing`.
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,6 +133,7 @@ Weightslab is a Python SDK to inspect, monitor, and edit training behavior for c
    agent
    hyperparameters
    logger
+   checkpointing
    .. weights_studio
 
 

--- a/tests/components/test_checkpoint_workflow.py
+++ b/tests/components/test_checkpoint_workflow.py
@@ -18,6 +18,8 @@ import tempfile
 import warnings
 import json
 import pandas as pd
+import yaml
+from unittest import mock
 
 warnings.filterwarnings("ignore")
 
@@ -1362,6 +1364,455 @@ class CheckpointStepAwareBehaviorTests(unittest.TestCase):
             self.assertIsNotNone(picked, "A checkpoint file should be selected")
             self.assertIn("_step_000005.pt", picked.name)
 
+    def test_load_latest_checkpoint_finds_file_under_model_hash_dir(self):
+        """Regression test: load_latest_checkpoint used to look for weight
+        files under models_dir/<full_24_byte_hash>/, but save_model_checkpoint
+        (and every other loader) stores them under models_dir/<model_hash>/
+        (the middle 8-byte segment) -- so it always returned None."""
+        with tempfile.TemporaryDirectory(prefix="load_latest_checkpoint_") as temp_dir:
+            manager = CheckpointManager(root_log_dir=temp_dir, load_model=False, load_config=False, load_data=False)
+            manager.current_exp_hash = "12345678abcdef0199aabbcc"
+
+            model = nn.Sequential(nn.Linear(3, 3))
+            manager.save_model_checkpoint(model=model, step=0, save_optimizer=False)
+            manager.save_model_checkpoint(model=model, step=9, save_optimizer=False)
+
+            loaded = manager.load_latest_checkpoint(model=nn.Sequential(nn.Linear(3, 3)), load_optimizer=False)
+            self.assertIsNotNone(loaded, "The latest checkpoint should be found and loaded")
+            self.assertEqual(loaded.get('step'), 9)
+
+
+class CheckpointMultiRootTests(unittest.TestCase):
+    """Tests for pointing a CheckpointManager at a parent directory that fans
+    out into several independent, nested experiment roots, e.g.:
+
+        scorer_exp/lr_tests/v1/checkpoints/manifest.yaml
+        scorer_exp/lr_tests/v2/checkpoints/manifest.yaml
+        scorer_exp/dataShuffling_tests/v1/checkpoints/manifest.yaml
+
+    The manager should transparently discover every nested root (up to
+    NESTED_ROOT_DISCOVERY_MAX_DEPTH levels down) and adopt the one with the
+    most recently updated manifest as its effective root, so model/config/
+    weight loading (and any future checkpoint writes) behave exactly like
+    the existing single root_log_dir case -- while merging signal-history
+    curves from every discovered root so training curves read as one
+    continuous history across all of them.
+    """
+
+    def setUp(self):
+        ledgers.clear_all()
+        self._tmp_ctx = tempfile.TemporaryDirectory(prefix="checkpoint_multiroot_")
+        self.tmp_dir = Path(self._tmp_ctx.name)
+
+    def tearDown(self):
+        ledgers.clear_all()
+        self._tmp_ctx.cleanup()
+
+    def _pin_manifest_timestamp(self, root_dir, exp_hash, timestamp):
+        """Overwrite a root's manifest recency timestamps with a controlled
+        value -- real datetime.now() ordering between fast successive setup
+        calls would otherwise make winner-selection non-deterministic."""
+        manifest_path = root_dir / "checkpoints" / "manifest.yaml"
+        with open(manifest_path, 'r') as f:
+            manifest = yaml.safe_load(f)
+        manifest['last_updated'] = timestamp
+        manifest['experiments'][exp_hash]['last_used'] = timestamp
+        manifest['experiments'][exp_hash]['created'] = timestamp
+        with open(manifest_path, 'w') as f:
+            yaml.dump(manifest, f, default_flow_style=False, sort_keys=False)
+
+    def _write_experiment_root(self, root_dir, exp_hash, step, timestamp, loss_values):
+        """Create a standalone, valid experiment root under root_dir: a
+        CheckpointManager with one model checkpoint and some logger signal
+        history tagged with exp_hash, with its manifest recency pinned to a
+        controlled timestamp (see _pin_manifest_timestamp)."""
+        manager = CheckpointManager(root_log_dir=str(root_dir), load_model=False, load_config=False, load_data=False)
+        manager.current_exp_hash = exp_hash
+        manager._create_exp_hash_directories(exp_hash)
+
+        model = nn.Sequential(nn.Linear(2, 2))
+        manager.save_model_checkpoint(model=model, step=step, save_optimizer=False)
+
+        lg = LoggerQueue(register=False, db_path=str(manager.get_logger_db_path()))
+        lg.chkpt_manager = manager  # tag signals with this root's own exp_hash
+        for i, value in enumerate(loss_values):
+            lg.add_scalars('loss', {'loss': value}, global_step=i, signal_per_sample={}, aggregate_by_step=False)
+        lg.flush_to_disk()
+        lg.stop_background_flush()
+        lg._conn.close()  # release the file lock so it can be ATTACHed for merging later
+
+        self._pin_manifest_timestamp(root_dir, exp_hash, timestamp)
+
+        ledgers.clear_all()
+        return manager
+
+    def test_fresh_empty_root_has_no_discovered_roots(self):
+        """A brand-new, never-used root_log_dir behaves exactly as before:
+        no nested roots are found, so nothing is adopted or merged."""
+        root = self.tmp_dir / "brand_new"
+        manager = CheckpointManager(root_log_dir=str(root), load_model=False, load_config=False, load_data=False)
+
+        self.assertEqual(manager.root_log_dir, root.absolute())
+        self.assertEqual(manager.given_root_log_dir, root.absolute())
+        self.assertEqual(manager.discovered_root_dirs, [])
+        self.assertFalse(manager.is_multi_root)
+
+    def test_single_preexisting_root_is_backward_compatible(self):
+        """Pointing directly at a single existing experiment root (the
+        current, common usage) must resolve to itself unchanged."""
+        root = self.tmp_dir / "single_exp"
+        exp_hash = "aaaa0000" + "bbbb0000" + "cccc0000"
+        self._write_experiment_root(root, exp_hash, step=3, timestamp="2024-01-01T00:00:00", loss_values=[0.9])
+
+        manager = CheckpointManager(root_log_dir=str(root), load_model=False, load_config=False, load_data=False)
+
+        self.assertEqual(manager.root_log_dir, root.absolute())
+        self.assertEqual(manager.discovered_root_dirs, [root.absolute()])
+        self.assertFalse(manager.is_multi_root)
+        self.assertEqual(manager.current_exp_hash, exp_hash)
+
+    def test_multiroot_with_single_nested_root_behaves_like_single_root(self):
+        """A parent directory that currently fans out into only one nested
+        root should adopt it exactly like the single-root case (no merging
+        needed since there's nothing to merge from)."""
+        parent = self.tmp_dir / "single_nested"
+        only_root = parent / "attempt_1"
+        exp_hash = "aaaa0004" + "bbbb0004" + "cccc0004"
+        self._write_experiment_root(only_root, exp_hash, step=7, timestamp="2024-03-01T00:00:00", loss_values=[0.5])
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+
+        self.assertEqual(manager.root_log_dir, only_root.absolute())
+        self.assertEqual(manager.discovered_root_dirs, [only_root.absolute()])
+        self.assertFalse(manager.is_multi_root)
+        self.assertEqual(manager.current_exp_hash, exp_hash)
+
+    def test_multiroot_adopts_most_recently_updated_nested_root(self):
+        """Given several nested roots at varying depths (as deep as the
+        max-depth-3 example from the feature request: parent/group/version),
+        the manager must adopt the most recently updated one for model/
+        weights/config, while merging logger curves from all of them."""
+        parent = self.tmp_dir / "scorer_exp"
+        root_old = parent / "lr_tests" / "v1"
+        root_mid = parent / "lr_tests" / "v2"
+        root_winner = parent / "dataShuffling_tests" / "v2"
+
+        hash_old = "aaaa0001" + "bbbb0001" + "cccc0001"
+        hash_mid = "aaaa0002" + "bbbb0002" + "cccc0002"
+        hash_winner = "aaaa0003" + "bbbb0003" + "cccc0003"
+
+        self._write_experiment_root(root_old, hash_old, step=10, timestamp="2024-01-01T00:00:00", loss_values=[2.0, 1.8])
+        self._write_experiment_root(root_mid, hash_mid, step=20, timestamp="2024-06-01T00:00:00", loss_values=[1.5, 1.3])
+        self._write_experiment_root(root_winner, hash_winner, step=30, timestamp="2025-01-01T00:00:00", loss_values=[1.0, 0.8])
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+
+        # --- Winner selection: model/config/data come entirely from the ---
+        # --- most recently updated nested root (same as single-root case) ---
+        self.assertEqual(manager.root_log_dir, root_winner.absolute())
+        self.assertTrue(manager.is_multi_root)
+        self.assertEqual(
+            set(manager.discovered_root_dirs),
+            {root_old.absolute(), root_mid.absolute(), root_winner.absolute()},
+        )
+        self.assertEqual(manager.current_exp_hash, hash_winner)
+
+        checkpoint_file = manager._select_weight_checkpoint_file(hash_winner)
+        self.assertIsNotNone(checkpoint_file, "Winner's own weight checkpoint should be found")
+        self.assertIn("_step_000030.pt", checkpoint_file.name)
+
+        result = manager.load_checkpoint(hash_winner, load_model=False, load_config=False, load_data=False)
+        self.assertIn('weights', result['loaded_components'])
+        self.assertEqual(
+            result['weights'].get('step'), 30,
+            "The most recent checkpoint across all manifests should be loaded",
+        )
+
+        # --- Logger curves: merged in from every discovered root, not ---
+        # --- just the winner's own ---
+        ledgers.register_checkpoint_manager(manager)
+        lg = LoggerQueue(register=True)
+        try:
+            history = lg.get_signal_history()
+            loss_by_hash = history.get('loss', {})
+            self.assertEqual(
+                set(loss_by_hash.keys()), {hash_old, hash_mid, hash_winner},
+                "Signal history should carry curves tagged with every discovered root's own hash",
+            )
+            total_points = sum(len(steps) for steps in loss_by_hash.values())
+            self.assertEqual(total_points, 6, "2 loss points from each of the 3 merged roots")
+        finally:
+            lg.stop_background_flush()
+
+    def test_sibling_merge_is_idempotent_across_call_sites(self):
+        """merge_from_disk can be triggered from more than one init-ordering
+        call site (logger created before vs. after the checkpoint manager);
+        merging the same sibling twice must not duplicate its rows."""
+        parent = self.tmp_dir / "idempotent_exp"
+        root_a = parent / "a"
+        root_b = parent / "b"
+        hash_a = "aaaa0005" + "bbbb0005" + "cccc0005"
+        hash_b = "aaaa0006" + "bbbb0006" + "cccc0006"
+
+        self._write_experiment_root(root_a, hash_a, step=1, timestamp="2024-01-01T00:00:00", loss_values=[1.0])
+        self._write_experiment_root(root_b, hash_b, step=2, timestamp="2024-02-01T00:00:00", loss_values=[2.0])
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+        ledgers.register_checkpoint_manager(manager)
+
+        lg = LoggerQueue(register=True)  # first merge trigger: LoggerQueue.__init__
+        try:
+            manager._merge_sibling_logger_histories()  # second, redundant trigger
+            manager._merge_sibling_logger_histories()  # third, redundant trigger
+
+            history = lg.get_signal_history()
+            loss_by_hash = history.get('loss', {})
+            self.assertEqual(len(loss_by_hash.get(hash_a, {})), 1, "Sibling root's rows must not be duplicated")
+        finally:
+            lg.stop_background_flush()
+
+    def test_discovery_respects_max_depth_cutoff(self):
+        """A root nested deeper than NESTED_ROOT_DISCOVERY_MAX_DEPTH levels
+        must not be discovered, even if it's the most recently updated one --
+        only what's actually found can be adopted."""
+        parent = self.tmp_dir / "depth_test"
+        within_depth = parent / "a" / "b" / "c"        # 3 levels down: in range
+        beyond_depth = parent / "w" / "x" / "y" / "z"  # 4 levels down: out of range
+
+        hash_within = "aaaa0007" + "bbbb0007" + "cccc0007"
+        hash_beyond = "aaaa0008" + "bbbb0008" + "cccc0008"
+        self._write_experiment_root(within_depth, hash_within, step=1, timestamp="2024-01-01T00:00:00", loss_values=[1.0])
+        # Deliberately the more "recent" one, to prove it's ignored for being unreachable.
+        self._write_experiment_root(beyond_depth, hash_beyond, step=1, timestamp="2025-01-01T00:00:00", loss_values=[1.0])
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+
+        discovered = set(manager.discovered_root_dirs)
+        self.assertIn(within_depth.absolute(), discovered)
+        self.assertNotIn(beyond_depth.absolute(), discovered)
+        self.assertEqual(manager.root_log_dir, within_depth.absolute())
+
+    def test_ranking_falls_back_to_experiment_timestamps_when_last_updated_missing(self):
+        """Older manifests may predate the top-level 'last_updated' field;
+        ranking should still work off the latest experiment's own timestamp."""
+        parent = self.tmp_dir / "legacy_timestamp_exp"
+        root_a = parent / "a"
+        root_b = parent / "b"
+        hash_a = "aaaa0009" + "bbbb0009" + "cccc0009"
+        hash_b = "aaaa0010" + "bbbb0010" + "cccc0010"
+        self._write_experiment_root(root_a, hash_a, step=1, timestamp="2024-01-01T00:00:00", loss_values=[1.0])
+        self._write_experiment_root(root_b, hash_b, step=1, timestamp="2025-01-01T00:00:00", loss_values=[1.0])
+
+        manifest_path = root_b / "checkpoints" / "manifest.yaml"
+        with open(manifest_path, 'r') as f:
+            manifest = yaml.safe_load(f)
+        del manifest['last_updated']
+        with open(manifest_path, 'w') as f:
+            yaml.dump(manifest, f, default_flow_style=False, sort_keys=False)
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+        self.assertEqual(
+            manager.root_log_dir, root_b.absolute(),
+            "Should still rank by the latest experiment's own timestamp when top-level last_updated is missing",
+        )
+
+    def test_corrupt_manifest_does_not_crash_discovery(self):
+        """One candidate's manifest.yaml being unparsable must not take down
+        discovery for the others -- it just can't win the ranking."""
+        parent = self.tmp_dir / "corrupt_manifest_exp"
+        root_good = parent / "good"
+        root_bad = parent / "bad"
+        hash_good = "aaaa0011" + "bbbb0011" + "cccc0011"
+        self._write_experiment_root(root_good, hash_good, step=1, timestamp="2024-01-01T00:00:00", loss_values=[1.0])
+
+        bad_checkpoints_dir = root_bad / "checkpoints"
+        bad_checkpoints_dir.mkdir(parents=True)
+        # Tab-indentation is invalid YAML syntax -- guaranteed to raise on parse.
+        (bad_checkpoints_dir / "manifest.yaml").write_text("experiments:\n\tbad: [\n")
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+        self.assertEqual(len(manager.discovered_root_dirs), 2, "Both roots should be discovered")
+        self.assertEqual(manager.root_log_dir, root_good.absolute(), "The corrupt manifest should rank last, not crash ranking")
+
+    def test_merges_legacy_json_snapshot_from_sibling_without_duckdb(self):
+        """A sibling root that predates DuckDB-backed logger persistence
+        (only an uncompressed loggers.json snapshot, no loggers.duckdb) must
+        still have its curves merged in via the legacy fallback path."""
+        parent = self.tmp_dir / "legacy_logger_exp"
+        root_legacy = parent / "legacy"
+        root_winner = parent / "current"
+        hash_legacy = "aaaa0012" + "bbbb0012" + "cccc0012"
+        hash_winner = "aaaa0013" + "bbbb0013" + "cccc0013"
+
+        legacy_manager = CheckpointManager(root_log_dir=str(root_legacy), load_model=False, load_config=False, load_data=False)
+        legacy_manager.current_exp_hash = hash_legacy
+        legacy_manager._create_exp_hash_directories(hash_legacy)
+        legacy_manager.save_model_checkpoint(model=nn.Sequential(nn.Linear(2, 2)), step=1, save_optimizer=False)
+        legacy_payload = {
+            "loggers": {
+                "main": {
+                    "graph_names": ["loss"],
+                    "signal_history": [
+                        {"metric_name": "loss", "experiment_hash": hash_legacy, "model_age": 0, "metric_value": 4.2},
+                    ],
+                }
+            }
+        }
+        with open(legacy_manager.loggers_dir / "loggers.json", "w") as f:
+            json.dump(legacy_payload, f)
+        self.assertFalse((legacy_manager.loggers_dir / "loggers.duckdb").exists(), "Precondition: no DuckDB file for this legacy root")
+        self._pin_manifest_timestamp(root_legacy, hash_legacy, "2024-01-01T00:00:00")
+        ledgers.clear_all()
+
+        self._write_experiment_root(root_winner, hash_winner, step=5, timestamp="2025-01-01T00:00:00", loss_values=[1.0])
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+        ledgers.register_checkpoint_manager(manager)
+        lg = LoggerQueue(register=True)
+        try:
+            history = lg.get_signal_history()
+            loss_by_hash = history.get('loss', {})
+            self.assertIn(hash_legacy, loss_by_hash, "Legacy JSON snapshot curves from a pre-DuckDB sibling should be merged")
+            self.assertEqual(loss_by_hash[hash_legacy][0][0]['metric_value'], 4.2)
+        finally:
+            lg.stop_background_flush()
+
+    def test_merge_sibling_logger_histories_survives_merge_from_disk_exception(self):
+        """If merging one sibling's on-disk history raises unexpectedly, the
+        whole init must not blow up -- it's logged and skipped."""
+        parent = self.tmp_dir / "raising_merge_exp"
+        root_a = parent / "a"
+        root_b = parent / "b"
+        hash_a = "aaaa0014" + "bbbb0014" + "cccc0014"
+        hash_b = "aaaa0015" + "bbbb0015" + "cccc0015"
+        self._write_experiment_root(root_a, hash_a, step=1, timestamp="2024-01-01T00:00:00", loss_values=[1.0])
+        self._write_experiment_root(root_b, hash_b, step=1, timestamp="2025-01-01T00:00:00", loss_values=[1.0])
+
+        manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+        ledgers.register_checkpoint_manager(manager)
+        lg = LoggerQueue(register=True)
+        try:
+            with mock.patch.object(lg, 'merge_from_disk', side_effect=RuntimeError("boom")):
+                manager._merge_sibling_logger_histories()  # must not raise
+        finally:
+            lg.stop_background_flush()
+
+    def test_merge_triggered_when_logger_predates_manager(self):
+        """The reverse init ordering: a LoggerQueue already exists BEFORE the
+        multi-root CheckpointManager is constructed. _bind_logger_to_disk
+        must still trigger the sibling merge once it binds the pre-existing
+        logger to the winner's on-disk history."""
+        parent = self.tmp_dir / "logger_first_exp"
+        root_a = parent / "a"
+        root_b = parent / "b"
+        hash_a = "aaaa0016" + "bbbb0016" + "cccc0016"
+        hash_b = "aaaa0017" + "bbbb0017" + "cccc0017"
+        self._write_experiment_root(root_a, hash_a, step=1, timestamp="2024-01-01T00:00:00", loss_values=[1.0])
+        self._write_experiment_root(root_b, hash_b, step=1, timestamp="2025-01-01T00:00:00", loss_values=[1.0])
+
+        lg = LoggerQueue(register=True)  # created before any CheckpointManager exists
+        try:
+            manager = CheckpointManager(root_log_dir=str(parent), load_model=False, load_config=False, load_data=False)
+            self.assertEqual(manager.root_log_dir, root_b.absolute())
+
+            history = lg.get_signal_history()
+            loss_by_hash = history.get('loss', {})
+            self.assertIn(hash_a, loss_by_hash, "Sibling root's curve should be merged once the pre-existing logger is bound to disk")
+            self.assertIn(hash_b, loss_by_hash, "Winner root's own curve should be present too (adopted from its on-disk file)")
+        finally:
+            lg.stop_background_flush()
+
+
+class LoggerQueueMergeFromDiskTests(unittest.TestCase):
+    """Focused unit tests for LoggerQueue.merge_from_disk's edge/failure
+    paths, isolated from the CheckpointManager multi-root scaffolding."""
+
+    class _FakeCheckpointManager:
+        def __init__(self, exp_hash):
+            self._exp_hash = exp_hash
+
+        def get_current_experiment_hash(self):
+            return self._exp_hash
+
+    def setUp(self):
+        ledgers.clear_all()
+        self._tmp_ctx = tempfile.TemporaryDirectory(prefix="logger_merge_")
+        self.tmp_dir = Path(self._tmp_ctx.name)
+
+    def tearDown(self):
+        ledgers.clear_all()
+        self._tmp_ctx.cleanup()
+
+    def _make_closed_db_with_signal(self, db_path, exp_hash, value, drop_table=None):
+        lg = LoggerQueue(register=False, db_path=str(db_path))
+        lg.chkpt_manager = self._FakeCheckpointManager(exp_hash)
+        lg.add_scalars('loss', {'loss': value}, global_step=0, signal_per_sample={}, aggregate_by_step=False)
+        lg.flush_to_disk()
+        if drop_table:
+            lg._conn.execute(f"DROP TABLE {drop_table}")
+        lg.stop_background_flush()
+        lg._conn.close()
+
+    def test_noop_for_falsy_path(self):
+        lg = LoggerQueue(register=False)
+        self.assertFalse(lg.merge_from_disk(None))
+        self.assertFalse(lg.merge_from_disk(""))
+        lg.stop_background_flush()
+
+    def test_noop_for_nonexistent_path(self):
+        lg = LoggerQueue(register=False)
+        self.assertFalse(lg.merge_from_disk(str(self.tmp_dir / "does_not_exist.duckdb")))
+        lg.stop_background_flush()
+
+    def test_noop_for_merging_self(self):
+        db_path = self.tmp_dir / "self.duckdb"
+        lg = LoggerQueue(register=False, db_path=str(db_path))
+        self.assertFalse(lg.merge_from_disk(str(db_path)), "Merging a logger's own backing file into itself must be a no-op")
+        lg.stop_background_flush()
+
+    def test_handles_corrupt_source_file_gracefully(self):
+        corrupt_path = self.tmp_dir / "corrupt.duckdb"
+        corrupt_path.write_bytes(b"this is not a duckdb file")
+
+        lg = LoggerQueue(register=False)
+        try:
+            self.assertFalse(lg.merge_from_disk(str(corrupt_path)))
+        finally:
+            lg.stop_background_flush()
+
+    def test_copies_rows_and_is_idempotent(self):
+        source_db = self.tmp_dir / "source.duckdb"
+        self._make_closed_db_with_signal(source_db, "srchash", 3.5)
+
+        lg = LoggerQueue(register=False)
+        try:
+            self.assertTrue(lg.merge_from_disk(str(source_db)))
+            history = lg.get_signal_history()
+            self.assertEqual(len(history.get('loss', {}).get('srchash', {})), 1)
+
+            self.assertFalse(lg.merge_from_disk(str(source_db)), "Re-merging the same source must be a no-op")
+            history_again = lg.get_signal_history()
+            self.assertEqual(
+                len(history_again.get('loss', {}).get('srchash', {})), 1,
+                "Rows must not be duplicated by a repeated merge",
+            )
+        finally:
+            lg.stop_background_flush()
+
+    def test_skips_missing_table_gracefully(self):
+        """An older-schema sibling DB might be missing a table entirely
+        (schema evolved since); the other tables should still merge."""
+        source_db = self.tmp_dir / "old_schema.duckdb"
+        self._make_closed_db_with_signal(source_db, "oldschemahash", 1.1, drop_table="per_instance")
+
+        lg = LoggerQueue(register=False)
+        try:
+            self.assertTrue(lg.merge_from_disk(str(source_db)))
+            history = lg.get_signal_history()
+            self.assertIn('oldschemahash', history.get('loss', {}))
+        finally:
+            lg.stop_background_flush()
+
 
 if __name__ == '__main__':
     # Create test suite with explicit ordering
@@ -1389,6 +1840,25 @@ if __name__ == '__main__':
     # # Step-aware hash/checkpoint behavior
     suite.addTest(CheckpointStepAwareBehaviorTests('test_model_hash_depends_on_init_step'))
     suite.addTest(CheckpointStepAwareBehaviorTests('test_selects_closest_weights_checkpoint_for_target_step'))
+    suite.addTest(CheckpointStepAwareBehaviorTests('test_load_latest_checkpoint_finds_file_under_model_hash_dir'))
+    # # Multi-root discovery (root_log_dir fanning out into nested experiment roots)
+    suite.addTest(CheckpointMultiRootTests('test_fresh_empty_root_has_no_discovered_roots'))
+    suite.addTest(CheckpointMultiRootTests('test_single_preexisting_root_is_backward_compatible'))
+    suite.addTest(CheckpointMultiRootTests('test_multiroot_with_single_nested_root_behaves_like_single_root'))
+    suite.addTest(CheckpointMultiRootTests('test_multiroot_adopts_most_recently_updated_nested_root'))
+    suite.addTest(CheckpointMultiRootTests('test_sibling_merge_is_idempotent_across_call_sites'))
+    suite.addTest(CheckpointMultiRootTests('test_discovery_respects_max_depth_cutoff'))
+    suite.addTest(CheckpointMultiRootTests('test_ranking_falls_back_to_experiment_timestamps_when_last_updated_missing'))
+    suite.addTest(CheckpointMultiRootTests('test_corrupt_manifest_does_not_crash_discovery'))
+    suite.addTest(CheckpointMultiRootTests('test_merges_legacy_json_snapshot_from_sibling_without_duckdb'))
+    suite.addTest(CheckpointMultiRootTests('test_merge_sibling_logger_histories_survives_merge_from_disk_exception'))
+    suite.addTest(CheckpointMultiRootTests('test_merge_triggered_when_logger_predates_manager'))
+    suite.addTest(LoggerQueueMergeFromDiskTests('test_noop_for_falsy_path'))
+    suite.addTest(LoggerQueueMergeFromDiskTests('test_noop_for_nonexistent_path'))
+    suite.addTest(LoggerQueueMergeFromDiskTests('test_noop_for_merging_self'))
+    suite.addTest(LoggerQueueMergeFromDiskTests('test_handles_corrupt_source_file_gracefully'))
+    suite.addTest(LoggerQueueMergeFromDiskTests('test_copies_rows_and_is_idempotent'))
+    suite.addTest(LoggerQueueMergeFromDiskTests('test_skips_missing_table_gracefully'))
 
     # Run the suite
     runner = unittest.TextTestRunner(verbosity=2)

--- a/weightslab/backend/logger.py
+++ b/weightslab/backend/logger.py
@@ -108,6 +108,11 @@ class LoggerQueue:
         self._stage_instance: list = []
         self._seq = 0
 
+        # Absolute paths of sibling DBs already merged in via merge_from_disk,
+        # so repeated merge triggers (logger can be bound to disk from three
+        # different call sites depending on init ordering) stay idempotent.
+        self._merged_source_dbs: set = set()
+
         # Per-sample query cache. Many consumers read the SAME (signal, ids) in
         # one step (e.g. reactive signals all reading the loss); memoize so N
         # identical reads cost 1 scan. Keyed by (signal, ids, [step,] hash,
@@ -146,6 +151,17 @@ class LoggerQueue:
                     self.set_db_path(os.path.join(str(loggers_dir), "loggers.duckdb"))
             except Exception:
                 pass
+
+        # Checkpoint manager was created before this logger and already
+        # resolved a multi-root parent directory — merge sibling roots' curves
+        # in now (the reverse ordering is handled by
+        # CheckpointManager._bind_logger_to_disk; merge_from_disk is
+        # idempotent so both call sites firing is harmless).
+        if getattr(self.chkpt_manager, "is_multi_root", False):
+            try:
+                self.chkpt_manager._merge_sibling_logger_histories()
+            except Exception as exc:
+                logger.warning(f"[LoggerQueue] Failed to merge multi-root sibling logger histories: {exc}")
 
         self._start_background_flush()
 
@@ -378,6 +394,63 @@ class LoggerQueue:
                     self._conn.execute("CHECKPOINT")
             except Exception as exc:
                 logger.warning(f"[LoggerQueue] flush_to_disk failed: {exc}")
+
+    def merge_from_disk(self, other_db_path) -> bool:
+        """Merge signal-history rows from another on-disk DuckDB file into
+        this logger's live tables.
+
+        Used to stitch training curves together from sibling experiment
+        roots discovered under a shared parent directory (see
+        CheckpointManager._merge_sibling_logger_histories). Purely additive:
+        rows are namespaced by ``experiment_hash``, so independent hash
+        chains from different roots never collide, and nothing already in
+        this logger is touched. A no-op (returns False) if the path doesn't
+        exist, is this same database, or the merge fails outright.
+        """
+        if not other_db_path:
+            return False
+        other_db_path = os.path.abspath(str(other_db_path))
+        if not os.path.exists(other_db_path):
+            return False
+        if self._db_path not in (None, ":memory:") and other_db_path == os.path.abspath(self._db_path):
+            return False
+
+        with self._lock:
+            if other_db_path in self._merged_source_dbs:
+                # Already merged (this can be triggered from more than one
+                # init-ordering call site) — skip to avoid duplicating rows.
+                return False
+
+            try:
+                self._flush_stage()
+                escaped = other_db_path.replace("'", "''")
+                self._conn.execute(f"ATTACH '{escaped}' AS incoming (READ_ONLY)")
+            except Exception as exc:
+                logger.warning(f"[LoggerQueue] Failed to attach {other_db_path} for merge: {exc}")
+                return False
+
+            try:
+                copied_any = False
+                for tbl in self._HISTORY_TABLES:
+                    try:
+                        self._conn.execute(f"INSERT INTO {tbl} SELECT * FROM incoming.{tbl}")
+                        copied_any = True
+                    except Exception as exc:
+                        # Table may be missing in an older-schema sibling DB;
+                        # skip it, other tables still merge.
+                        logger.debug(f"[LoggerQueue] Skipped merging table '{tbl}' from {other_db_path}: {exc}")
+            finally:
+                try:
+                    self._conn.execute("DETACH incoming")
+                except Exception:
+                    pass
+
+            if copied_any:
+                self._merged_source_dbs.add(other_db_path)
+                self._invalidate_qps_cache()
+                self._restore_runtime_state_from_db()
+                logger.info(f"[LoggerQueue] Merged signal history from {other_db_path}")
+            return copied_any
 
     def _restore_runtime_state_from_db(self) -> None:
         """Repopulate seq counter and graph names from an existing (file) DB."""

--- a/weightslab/components/checkpoint_manager.py
+++ b/weightslab/components/checkpoint_manager.py
@@ -82,11 +82,26 @@ class CheckpointManager:
     LOGGER_SNAPSHOT_CHUNK_SUFFIX = ".json.zst"
     LOGGER_SNAPSHOT_MANIFEST_FILE = "loggers.manifest.json"
 
+    # How many levels of subdirectories below a given root_log_dir to scan
+    # when looking for nested experiment roots (see _discover_nested_root_dirs).
+    NESTED_ROOT_DISCOVERY_MAX_DEPTH = 3
+
     def __init__(self, root_log_dir: str = 'root_experiment', load_model: bool = True, load_config: bool = False, load_data: bool = True):
         """Initialize the checkpoint manager.
 
         Args:
-            root_log_dir: Root directory for experiment outputs
+            root_log_dir: Root directory for experiment outputs. This may
+                either be a single experiment's own root (containing
+                ``checkpoints/manifest.yaml`` directly) or a parent directory
+                that fans out into several such experiment roots nested a few
+                levels down (e.g. ``root/lr_tests/v1``, ``root/lr_tests/v2``).
+                In the latter case the manager auto-discovers every nested
+                root (see :meth:`_discover_nested_root_dirs`), adopts the one
+                with the most recently updated manifest as its effective
+                root (so model/config/data loading and future writes behave
+                exactly as the single-root case), and merges signal-history
+                curves from the other discovered roots so logger curves read
+                as one continuous history across all of them.
         """
         # root_log_dir may arrive as a ledger Proxy / ValueProxy — e.g. when a caller
         # passes ``config.get('root_log_dir')`` straight from the watched hyperparameters.
@@ -94,8 +109,16 @@ class CheckpointManager:
         # type() (the proxy overrides __class__/isinstance to masquerade as its wrapped
         # value, so isinstance checks are unreliable), and fall back to the default when
         # the proxy is unset / resolves to None or empty.
-        self.root_log_dir = Path(str(root_log_dir)).absolute()
+        given_root_log_dir = Path(str(root_log_dir)).absolute()
+        given_root_log_dir.mkdir(parents=True, exist_ok=True)
+
+        # The directory actually passed in, kept around for reference even
+        # when we adopt a nested directory below as the effective root.
+        self.given_root_log_dir = given_root_log_dir
+        self.root_log_dir, self.discovered_root_dirs = self._resolve_effective_root_dir(given_root_log_dir)
         self.root_log_dir.mkdir(parents=True, exist_ok=True)
+        self.is_multi_root = len(self.discovered_root_dirs) > 1
+
         self.config = ledgers.get_hyperparams() or {}
 
         # Create main subdirectories
@@ -149,18 +172,174 @@ class CheckpointManager:
         # Load any existing logger snapshots for visibility when starting
         self._load_all_logger_snapshots()
 
+        # If root_log_dir fanned out into several nested experiment roots,
+        # stitch signal-history curves from the other ones into this logger
+        # too (model/config/data only ever come from the chosen effective root).
+        if self.is_multi_root:
+            self._merge_sibling_logger_histories()
+
         # Automatically resume latest state when an existing root_log_dir is provided
         self._bootstrap_latest_state(load_model=load_model, load_config=load_config, load_data=load_data, force=self.first_time)
         logger.info(f"CheckpointManager initialized at {self.root_log_dir}")
 
     def __repr__(self) -> str:
+        multi_root_info = (
+            f" discovered_root_dirs={len(self.discovered_root_dirs)} (given_root_log_dir={self.given_root_log_dir})\n"
+            if self.is_multi_root else ""
+        )
         return (
             f"CheckpointManager(\n"
             f" root_log_dir={self.root_log_dir}\n"
+            f"{multi_root_info}"
             f" current_exp_hash={self.current_exp_hash}\n"
             f" step_counter={self._step_counter}\n"
             f")"
         )
+
+    # =========================
+    # MULTI-ROOT DISCOVERY
+    # =========================
+    def _discover_nested_root_dirs(self, base_dir: Path, max_depth: Optional[int] = None) -> List[Path]:
+        """Find directories under ``base_dir`` that look like a checkpoint
+        manager root, i.e. contain ``checkpoints/manifest.yaml``.
+
+        ``base_dir`` itself is checked at depth 0, so a plain single-experiment
+        root_log_dir (the existing, common case) is always returned as its own
+        sole candidate. Nested roots are searched up to ``max_depth`` levels of
+        subdirectories below ``base_dir`` (e.g. ``base_dir/lr_tests/v1`` is 2
+        levels down), which lets one parent directory fan out into several
+        independent experiment roots (different HP sweeps, restarts, etc.).
+        """
+        if max_depth is None:
+            max_depth = self.NESTED_ROOT_DISCOVERY_MAX_DEPTH
+
+        found: List[Path] = []
+
+        def _is_candidate(d: Path) -> bool:
+            return (d / "checkpoints" / "manifest.yaml").is_file()
+
+        def _walk(d: Path, depth: int) -> None:
+            if not d.is_dir():
+                return
+            if _is_candidate(d):
+                found.append(d)
+            if depth >= max_depth:
+                return
+            try:
+                children = sorted(p for p in d.iterdir() if p.is_dir())
+            except OSError:
+                return
+            for child in children:
+                # Don't descend into a root's own checkpoints/ internals —
+                # they hold model/HP/data/logger files, never further roots.
+                if child.name == "checkpoints" or child.name.startswith('.'):
+                    continue
+                _walk(child, depth + 1)
+
+        _walk(base_dir, 0)
+        return found
+
+    def _read_root_manifest_timestamp(self, candidate_dir: Path) -> str:
+        """Best-effort recency timestamp for a discovered root, used to rank
+        candidates. ISO-8601 strings (as produced everywhere in this module)
+        sort correctly with plain string comparison."""
+        manifest_file = candidate_dir / "checkpoints" / "manifest.yaml"
+        try:
+            with open(manifest_file, 'r') as f:
+                manifest = yaml.safe_load(f) or {}
+        except Exception:
+            return ""
+
+        timestamp = manifest.get('last_updated')
+        if timestamp:
+            return str(timestamp)
+
+        # Fall back to the latest experiment's own timestamps if the manifest
+        # predates the top-level 'last_updated' field.
+        latest_hash = manifest.get('latest_hash')
+        experiments = manifest.get('experiments', {}) or {}
+        exp_info = experiments.get(latest_hash, {}) if latest_hash else {}
+        return str(exp_info.get('last_used') or exp_info.get('created') or "")
+
+    def _resolve_effective_root_dir(self, given_root_log_dir: Path) -> tuple[Path, List[Path]]:
+        """Resolve the directory the manager should actually operate on.
+
+        Returns ``(effective_root, discovered_root_dirs)``:
+        - No nested roots found at all (brand-new/empty directory):
+          ``(given_root_log_dir, [])`` — identical to prior behavior.
+        - Exactly one root found (possibly ``given_root_log_dir`` itself):
+          that one is adopted as-is, ``discovered_root_dirs`` has length 1.
+        - Multiple roots found: the one with the most recently updated
+          manifest is adopted as the effective root (so model/config/data
+          loading, and future checkpoint writes, behave exactly like the
+          single-root case); all discovered roots are kept so their logger
+          curves can be merged (see :meth:`_merge_sibling_logger_histories`).
+        """
+        candidates = self._discover_nested_root_dirs(given_root_log_dir)
+        if not candidates:
+            return given_root_log_dir, []
+        if len(candidates) == 1:
+            return candidates[0], candidates
+
+        ranked = sorted(candidates, key=lambda d: (self._read_root_manifest_timestamp(d), str(d)))
+        winner = ranked[-1]
+        logger.info(
+            f"Discovered {len(candidates)} nested checkpoint roots under {given_root_log_dir}; "
+            f"using most recently updated as effective root: {winner}"
+        )
+        return winner, candidates
+
+    def _merge_sibling_logger_histories(self) -> None:
+        """Pull signal-history curves from the other discovered nested roots
+        into the active logger(s), so training curves read as one continuous
+        history across independent experiment roots that share a parent
+        directory. Model/config/data are never merged this way — they only
+        ever come from the chosen effective root (see _resolve_effective_root_dir).
+
+        Prefers merging directly from each sibling's on-disk DuckDB file
+        (additive at the SQL level: rows are namespaced by experiment_hash,
+        so independent hash chains never collide). Falls back to the legacy
+        JSON snapshot format for siblings that predate DuckDB persistence.
+
+        Requires an already-registered logger to merge into. If none exists
+        yet (e.g. this manager was constructed before any LoggerQueue),
+        every merge below is a no-op (the ``hasattr`` guards fail against an
+        unset ledger placeholder) rather than spinning up a throwaway
+        in-memory logger — doing so would occupy the default registry slot
+        with an object that never gets disk-bound, silently orphaning it
+        once the "real" logger is created afterwards. Safe to skip: this
+        method is also called from _bind_logger_to_disk and
+        LoggerQueue.__init__, both of which fire once a logger genuinely
+        exists (merge_from_disk is idempotent, so running this more than
+        once is harmless).
+        """
+        lg = ledgers.get_logger()
+
+        for candidate in self.discovered_root_dirs:
+            if candidate == self.root_log_dir:
+                continue
+
+            sibling_loggers_dir = candidate / "checkpoints" / "loggers"
+            sibling_db_path = sibling_loggers_dir / "loggers.duckdb"
+            merged = False
+
+            if sibling_db_path.exists() and hasattr(lg, 'merge_from_disk'):
+                try:
+                    merged = lg.merge_from_disk(str(sibling_db_path))
+                except Exception as e:
+                    logger.warning(f"Failed to merge on-disk logger history from sibling root {candidate}: {e}")
+
+            if not merged and hasattr(lg, 'load_snapshot'):
+                try:
+                    payload = self._load_logger_snapshot_payload(loggers_dir=sibling_loggers_dir)
+                    for lname, lpayload in payload.get('loggers', {}).items() if payload else ():
+                        # Merge into the already-registered logger for that name
+                        # when there is one, otherwise the current default logger.
+                        target_lg = ledgers.get_logger(lname) if lname in ledgers.list_loggers() else lg
+                        if hasattr(target_lg, 'load_snapshot'):
+                            target_lg.load_snapshot(lpayload)
+                except Exception as e:
+                    logger.warning(f"Failed to merge legacy logger snapshot from sibling root {candidate}: {e}")
 
     def _get_data_state_snapshot(self, dfm):
         """Return a combined data state from registered dataloaders, if present."""
@@ -212,6 +391,11 @@ class CheckpointManager:
             lg = ledgers.get_logger()
             if lg is not None and hasattr(lg, "set_db_path"):
                 lg.set_db_path(str(self.get_logger_db_path()))
+                # Logger already existed (created before this manager) — merge
+                # sibling curves now rather than waiting for the later call in
+                # __init__ (see _merge_sibling_logger_histories; idempotent).
+                if getattr(self, "is_multi_root", False):
+                    self._merge_sibling_logger_histories()
         except Exception as e:
             logger.warning(f"Could not bind logger to on-disk DuckDB: {e}")
 
@@ -224,28 +408,34 @@ class CheckpointManager:
         except Exception as e:
             logger.warning(f"Could not flush logger to disk: {e}")
 
-    def _get_logger_snapshot_dir(self) -> Path:
-        return self.loggers_dir
+    def _get_logger_snapshot_dir(self, loggers_dir: Optional[Path] = None) -> Path:
+        return loggers_dir if loggers_dir is not None else self.loggers_dir
 
-    def _get_logger_snapshot_path(self) -> Path:
-        return self._get_logger_snapshot_dir() / "loggers.json"
+    def _get_logger_snapshot_path(self, loggers_dir: Optional[Path] = None) -> Path:
+        return self._get_logger_snapshot_dir(loggers_dir) / "loggers.json"
 
-    def _get_logger_snapshot_manifest_path(self) -> Path:
-        return self._get_logger_snapshot_dir() / self.LOGGER_SNAPSHOT_MANIFEST_FILE
+    def _get_logger_snapshot_manifest_path(self, loggers_dir: Optional[Path] = None) -> Path:
+        return self._get_logger_snapshot_dir(loggers_dir) / self.LOGGER_SNAPSHOT_MANIFEST_FILE
 
     def _get_logger_snapshot_chunk_path(self, chunk_index: int) -> Path:
         fname = f"{self.LOGGER_SNAPSHOT_CHUNK_PREFIX}{chunk_index:04d}{self.LOGGER_SNAPSHOT_CHUNK_SUFFIX}"
         return self._get_logger_snapshot_dir() / fname
 
-    def _list_logger_snapshot_chunks(self) -> List[Path]:
-        snapshot_dir = self._get_logger_snapshot_dir()
+    def _list_logger_snapshot_chunks(self, loggers_dir: Optional[Path] = None) -> List[Path]:
+        snapshot_dir = self._get_logger_snapshot_dir(loggers_dir)
         if not snapshot_dir.exists():
             return []
         return sorted(snapshot_dir.glob(f"{self.LOGGER_SNAPSHOT_CHUNK_PREFIX}*{self.LOGGER_SNAPSHOT_CHUNK_SUFFIX}"))
 
-    def _load_logger_snapshot_payload(self) -> Dict[str, Any]:
-        snapshot_dir = self._get_logger_snapshot_dir()
-        manifest_path = self._get_logger_snapshot_manifest_path()
+    def _load_logger_snapshot_payload(self, loggers_dir: Optional[Path] = None) -> Dict[str, Any]:
+        """Load the (chunked, zstd-compressed) logger snapshot payload from
+        ``loggers_dir`` (defaults to this manager's own loggers_dir), falling
+        back to the legacy uncompressed JSON layout. Used both for this
+        manager's own startup load and to read a sibling root's snapshot when
+        merging multi-root logger curves (see _merge_sibling_logger_histories).
+        """
+        snapshot_dir = self._get_logger_snapshot_dir(loggers_dir)
+        manifest_path = self._get_logger_snapshot_manifest_path(loggers_dir)
 
         chunk_paths: List[Path] = []
         if manifest_path.exists():
@@ -258,7 +448,7 @@ class CheckpointManager:
                 logger.warning(f"Failed to read logger snapshot manifest for {manifest_path}: {e}")
 
         if not chunk_paths:
-            chunk_paths = self._list_logger_snapshot_chunks()
+            chunk_paths = self._list_logger_snapshot_chunks(loggers_dir)
 
         if chunk_paths:
             snapshot = {"timestamp": datetime.now().isoformat(), "loggers": {}}
@@ -286,8 +476,8 @@ class CheckpointManager:
 
         # Legacy layout fallback (new per-exp first, then old global file)
         legacy_candidates = [
-            self._get_logger_snapshot_path(),
-            self.loggers_dir / "loggers.json",
+            self._get_logger_snapshot_path(loggers_dir),
+            snapshot_dir / "loggers.json",
         ]
         for legacy_path in legacy_candidates:
             if not legacy_path.exists():
@@ -1527,8 +1717,10 @@ class CheckpointManager:
             logger.warning("No experiment hash specified")
             return None
 
-        # Find latest checkpoint
-        model_dir = self.models_dir / target_hash
+        # Find latest checkpoint. Weight files live under the model-hash-segment
+        # directory (models_dir/<model_hash>/), not one named after the full
+        # 24-byte combined hash — see save_model_checkpoint / _select_weight_checkpoint_file.
+        model_dir = self.models_dir / target_hash[8:-8]
 
         if not model_dir.exists():
             logger.warning(f"No checkpoints found for hash {target_hash}")
@@ -1582,24 +1774,36 @@ class CheckpointManager:
             logger.error(f"Failed to load checkpoint: {e}")
             return None
 
-    def load_logger_snapshot(self) -> bool:
-        """Load logger queues from snapshot for the current experiment hash."""
+    def _apply_logger_snapshot_payload(self, snapshot: Dict[str, Any]) -> bool:
+        """Restore (or merge into) registered logger queues from an already
+        loaded ``{"loggers": {name: payload}}`` snapshot dict. Additive:
+        existing history in each named logger is kept, the snapshot's rows
+        are staged on top of it. Shared by this manager's own startup load
+        and by the multi-root sibling merge path."""
+        loggers_payload = snapshot.get("loggers", {}) if snapshot else {}
+        for lname, payload in loggers_payload.items():
+            try:
+                lg = ledgers.get_logger(lname) if lname in ledgers.list_loggers() else None
+                if lg is None or not hasattr(lg, "load_snapshot"):
+                    lg = LoggerQueue(register=False)
+                    ledgers.register_logger(lg, name=lname)
+                lg.load_snapshot(payload)
+            except Exception as inner_e:
+                logger.warning(f"Failed to restore logger '{lname}': {inner_e}")
+        return True
+
+    def load_logger_snapshot(self, loggers_dir: Optional[Path] = None) -> bool:
+        """Load logger queues from snapshot for the current experiment hash.
+
+        ``loggers_dir`` defaults to this manager's own loggers_dir; pass a
+        sibling root's loggers dir to merge its curves in instead (see
+        _merge_sibling_logger_histories).
+        """
         try:
-            snapshot = self._load_logger_snapshot_payload()
+            snapshot = self._load_logger_snapshot_payload(loggers_dir)
             if not snapshot:
                 return False
-
-            loggers_payload = snapshot.get("loggers", {})
-            for lname, payload in loggers_payload.items():
-                try:
-                    lg = ledgers.get_logger(lname) if lname in ledgers.list_loggers() else None
-                    if lg is None or not hasattr(lg, "load_snapshot"):
-                        lg = LoggerQueue(register=False)
-                        ledgers.register_logger(lg, name=lname)
-                    lg.load_snapshot(payload)
-                except Exception as inner_e:
-                    logger.warning(f"Failed to restore logger '{lname}': {inner_e}")
-            return True
+            return self._apply_logger_snapshot_payload(snapshot)
         except Exception as e:
             logger.warning(f"Failed to load logger snapshot: {e}")
             return False


### PR DESCRIPTION
root_log_dir can now point at a parent directory that fans out into several independent, nested experiment roots (up to 3 levels deep). The manager discovers all of them, adopts the one with the most recently updated manifest for model/config/weights/data loading (and future writes), and merges signal-history curves from every discovered root so training curves read as one continuous history.

Also fixes CheckpointManager.load_latest_checkpoint(), which looked for weight files under models_dir/<full_hash>/ instead of models_dir/<model_hash>/ and so never found anything.

Adds docs/checkpointing.rst covering experiment hashing/versioning, the manifest, reproducibility, and the new multi-root behavior.