### PR TITLE
Fix sandbox link and streamline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,7 @@ wl.serve(serving_grpc=True, serving_cli=False)
 > weightslab start example --clus     # clustering
 > ```
 >
-> Explore our [sandbox](www.sandbox.graybx.com).
-
-For a detailed installation guide and advanced configuration &rarr; [Documentation](https://grayboxtech.github.io/weightslab/latest/quickstart.html).
+Explore our [sandbox](https://sandbox.graybx.com/). For a detailed installation guide and advanced configuration: [Documentation](https://grayboxtech.github.io/weightslab/latest/quickstart.html).
 
 <br>
 


### PR DESCRIPTION
Updated sandbox link to use HTTPS and removed redundant documentation line.