### PR TITLE
Add public model graph and editing API

### DIFF
--- a/docs/model_interaction.rst
+++ b/docs/model_interaction.rst
@@ -36,9 +36,59 @@ Minimal example
        log=True,
    )
 
+Model graph and editing API
+---------------------------
+
+Model editing needs dependency information so a change to one layer can be
+propagated to connected layers. Enable it when wrapping the model:
+
+.. code-block:: python
+
+   model = wl.watch_or_edit(
+       my_model,
+       flag="model",
+       dummy_input=example_batch,
+       compute_dependencies=True,
+   )
+
+   graph = model.get_model_graph()
+   first_layer = model.get_layer_info(graph["layers"][0]["id"])
+
+``get_model_graph()`` returns JSON-serializable primitives with a schema
+version, model metadata, layers, and directed dependencies. Each dependency is
+one of:
+
+- ``SAME``: both layers expose the same neuron/channel dimension, such as a
+  convolution followed by batch normalization.
+- ``INCOMING``: the source output feeds the destination input, such as one
+  linear layer feeding another.
+- ``REC``: a recursive or skip-connection relationship that must be kept in
+  sync during structural edits.
+
+The structural graph omits per-neuron records by default to keep inspection
+cheap. Use ``get_model_graph(include_neurons=True)`` or
+``get_layer_info(layer_id)`` for learning-rate and frozen-state details.
+
+The model exposes dependency-aware modifiers:
+
+.. code-block:: python
+
+   model.freeze_neurons(layer_id=0, neuron_indices=[0, 2])
+   model.unfreeze_neurons(layer_id=0, neuron_indices=[0])
+   model.reset_neurons(layer_id=0, neuron_indices=[1])
+   model.perturb_neurons(layer_id=0, neuron_indices=[2], ratio=0.1)
+   model.add_neurons(layer_id=0, count=2)
+   model.prune_neurons(layer_id=0, neuron_indices=[3])
+
+Omitting ``neuron_indices`` freezes, unfreezes, resets, or perturbs the whole
+layer. Layer ids are stable only for the lifetime of the wrapped model; resolve
+them from the graph instead of persisting them as checkpoint identifiers.
+
 Best practices
 --------------
 
 - Use explicit names for losses/metrics to keep logs readable.
 - Prefer ``per_sample=True`` for losses when you need hard-example analysis.
 - Keep model/device arguments explicit to avoid ambiguity in multi-device setups.
+- Pause training before structural edits so model and optimizer updates happen
+  at a safe boundary.

--- a/tests/model/test_model_graph_api.py
+++ b/tests/model/test_model_graph_api.py
@@ -1,0 +1,92 @@
+import json
+import unittest
+
+import torch
+import torch.nn as nn
+
+from weightslab.backend import ledgers
+from weightslab.backend.model_interface import ModelInterface
+
+
+class TestModelGraphApi(unittest.TestCase):
+    def tearDown(self):
+        ledgers.clear_all()
+
+    @staticmethod
+    def _wrapped_model():
+        model = nn.Sequential(
+            nn.Linear(4, 3),
+            nn.ReLU(),
+            nn.Linear(3, 2),
+        )
+        wrapped = ModelInterface(
+            model,
+            dummy_input=torch.randn(1, 4),
+            compute_dependencies=True,
+            register=False,
+            skip_previous_auto_load=True,
+        )
+        # Architecture-change hooks update registered optimizers. These focused
+        # API tests do not register one, so avoid unrelated ledger work.
+        wrapped._architecture_change_hook_fns = []
+        return wrapped
+
+    def test_get_model_graph_returns_serializable_structure(self):
+        model = self._wrapped_model()
+
+        graph = model.get_model_graph()
+
+        self.assertEqual(graph["schema_version"], 1)
+        self.assertEqual([layer["name"] for layer in graph["layers"]], ["0", "1", "2"])
+        self.assertEqual(
+            graph["dependencies"],
+            [
+                {"source_layer_id": 0, "target_layer_id": 1, "type": "SAME"},
+                {"source_layer_id": 1, "target_layer_id": 2, "type": "INCOMING"},
+            ],
+        )
+        self.assertNotIn("neurons", graph["layers"][0])
+        json.dumps(graph)
+
+    def test_layer_info_and_modifiers_update_the_live_model(self):
+        model = self._wrapped_model()
+
+        layer = model.get_layer_info(0)
+        self.assertEqual(layer["type"], "Linear")
+        self.assertEqual(layer["input_neurons"], 4)
+        self.assertEqual(layer["output_neurons"], 3)
+        self.assertEqual(len(layer["neurons"]), 3)
+
+        model.freeze_neurons(0, [0])
+        self.assertTrue(model.get_layer_info(0)["neurons"][0]["frozen"])
+
+        # Freezing twice is idempotent rather than toggling the state.
+        model.freeze_neurons(0, [0])
+        self.assertTrue(model.get_layer_info(0)["neurons"][0]["frozen"])
+        self.assertEqual(model.get_layer_info(0)["operation_counts"]["FREEZE"], 1)
+
+        model.unfreeze_neurons(0, [0])
+        self.assertFalse(model.get_layer_info(0)["neurons"][0]["frozen"])
+
+        model.add_neurons(0, count=2)
+        self.assertEqual(model.get_layer_info(0)["output_neurons"], 5)
+        self.assertEqual(model.get_layer_info(2)["input_neurons"], 5)
+        self.assertEqual(tuple(model(torch.randn(1, 4)).shape), (1, 2))
+
+    def test_modelling_api_rejects_ambiguous_or_invalid_targets(self):
+        model = self._wrapped_model()
+
+        with self.assertRaisesRegex(ValueError, "Unknown layer id"):
+            model.get_layer_info(99)
+        with self.assertRaisesRegex(ValueError, "cannot be empty"):
+            model.prune_neurons(0, [])
+        with self.assertRaisesRegex(ValueError, "outside layer 0"):
+            model.reset_neurons(0, [3])
+        with self.assertRaisesRegex(ValueError, "no learnable weights"):
+            model.freeze_neurons(1, [0])
+        with self.assertRaisesRegex(ValueError, "strictly between 0 and 1"):
+            model.perturb_neurons(0, [0], ratio=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weightslab/models/model_with_ops.py
+++ b/weightslab/models/model_with_ops.py
@@ -3,9 +3,10 @@ import torch as th
 
 from torch import nn
 from enum import Enum
-from typing import List, Set, Optional, Callable, Dict, Any
+from typing import Iterable, List, Set, Optional, Callable, Dict, Any
 
 from weightslab.components.tracking import TrackingMode
+from weightslab.modules.neuron_ops import ArchitectureNeuronsOpType
 from weightslab.utils.tools import get_children
 from weightslab.utils.modules_dependencies import _ModulesDependencyManager, DepType
 
@@ -104,7 +105,287 @@ class NetworkWithOps(nn.Module):
         return self.name
 
     def get_layer_by_id(self, layer_id: int):
-        return self._dep_manager.id_2_layer[layer_id]
+        layer = self._dep_manager.id_2_layer.get(layer_id)
+        if layer is None:
+            available = sorted(self._dep_manager.id_2_layer)
+            raise ValueError(
+                f"Unknown layer id {layer_id}. Available layer ids: {available}. "
+                "Wrap the model with compute_dependencies=True before using "
+                "the modelling API."
+            )
+        return layer
+
+    def _layer_names_by_id(self) -> Dict[int, str]:
+        """Return qualified PyTorch names for the registered editable layers."""
+        root = getattr(self, "model", None)
+        if not isinstance(root, nn.Module):
+            root = self
+
+        names = {}
+        for qualified_name, module in root.named_modules():
+            get_module_id = getattr(module, "get_module_id", None)
+            if not callable(get_module_id):
+                continue
+            try:
+                names[get_module_id()] = qualified_name or "<root>"
+            except (AttributeError, TypeError):
+                continue
+        return names
+
+    @staticmethod
+    def _neuron_count(layer: nn.Module, attribute: str) -> Optional[int]:
+        getter = getattr(layer, "get_neurons", None)
+        try:
+            value = getter(attribute) if callable(getter) else getattr(layer, attribute, None)
+        except (AttributeError, TypeError, ValueError):
+            value = getattr(layer, attribute, None)
+        return int(value) if isinstance(value, (int, float)) else None
+
+    def get_layer_info(
+        self,
+        layer_id: int,
+        *,
+        include_neurons: bool = True,
+    ) -> Dict[str, Any]:
+        """Return a JSON-serializable description of one editable layer.
+
+        Layer ids are stable for the lifetime of a wrapped model. They are not
+        checkpoint identifiers and may change when a new model is wrapped.
+        """
+        return self._build_layer_info(
+            layer_id,
+            include_neurons=include_neurons,
+            layer_names=self._layer_names_by_id(),
+        )
+
+    def _build_layer_info(
+        self,
+        layer_id: int,
+        *,
+        include_neurons: bool,
+        layer_names: Dict[int, str],
+    ) -> Dict[str, Any]:
+        layer = self.get_layer_by_id(layer_id)
+        input_neurons = self._neuron_count(layer, "in_neurons")
+        output_neurons = self._neuron_count(layer, "out_neurons")
+
+        lr_overrides = getattr(layer, "neuron_2_lr", {})
+        weight_lrs = lr_overrides.get("weight", {}) if lr_overrides else {}
+        neuron_count = output_neurons or 0
+        neuron_lrs = [float(weight_lrs.get(index, 1.0)) for index in range(neuron_count)]
+        frozen_neurons = {index for index, lr in enumerate(neuron_lrs) if lr == 0.0}
+
+        layer_info = {
+            "id": int(layer_id),
+            "name": layer_names.get(layer_id, f"layer_{layer_id}"),
+            "type": getattr(layer, "module_name", layer.__class__.__name__),
+            "input_neurons": input_neurons,
+            "output_neurons": output_neurons,
+            "parameter_count": sum(
+                parameter.numel() for parameter in layer.parameters(recurse=False)
+            ),
+            "frozen_neuron_count": len(frozen_neurons),
+            "operation_counts": dict(getattr(layer, "operation_age", {})),
+        }
+        if include_neurons:
+            layer_info["neurons"] = [
+                {
+                    "id": index,
+                    "learning_rate": neuron_lrs[index],
+                    "frozen": index in frozen_neurons,
+                }
+                for index in range(neuron_count)
+            ]
+        return layer_info
+
+    def get_model_graph(self, *, include_neurons: bool = False) -> Dict[str, Any]:
+        """Return the editable model graph as JSON-serializable primitives.
+
+        The default response is intentionally structural and cheap. Pass
+        ``include_neurons=True`` when per-neuron learning-rate/frozen state is
+        needed.
+        """
+        layer_ids = sorted(self._dep_manager.id_2_layer)
+        if not layer_ids:
+            raise RuntimeError(
+                "Model graph information is unavailable. Wrap the model with "
+                "wl.watch_or_edit(..., flag='model', compute_dependencies=True)."
+            )
+
+        dependency_edges = set()
+        for dependency_type, parents in self._dep_manager.dependency_2_id_2_id.items():
+            for source_id, target_ids in parents.items():
+                dependency_edges.update(
+                    (int(source_id), int(target_id), dependency_type.value)
+                    for target_id in target_ids
+                )
+        dependencies = [
+            {
+                "source_layer_id": source_id,
+                "target_layer_id": target_id,
+                "type": dependency_type,
+            }
+            for source_id, target_id, dependency_type in sorted(dependency_edges)
+        ]
+        layer_names = self._layer_names_by_id()
+
+        return {
+            "schema_version": 1,
+            "name": self.get_name(),
+            "age": self.get_age(),
+            "layers": [
+                self._build_layer_info(
+                    layer_id,
+                    include_neurons=include_neurons,
+                    layer_names=layer_names,
+                )
+                for layer_id in layer_ids
+            ],
+            "dependencies": dependencies,
+        }
+
+    def _validated_neuron_indices(
+        self,
+        layer_id: int,
+        neuron_indices: Optional[Iterable[int] | int],
+        *,
+        allow_empty: bool,
+    ) -> Set[int]:
+        layer = self.get_layer_by_id(layer_id)
+        neuron_count = self._neuron_count(layer, "out_neurons")
+        if neuron_count is None:
+            raise ValueError(f"Layer {layer_id} does not expose output neurons.")
+
+        if neuron_indices is None:
+            indices = set()
+        elif isinstance(neuron_indices, int):
+            indices = {neuron_indices}
+        else:
+            indices = set(neuron_indices)
+        if not all(isinstance(index, int) for index in indices):
+            raise TypeError("neuron_indices must contain integers only.")
+        if not indices and not allow_empty:
+            raise ValueError("neuron_indices cannot be empty for this operation.")
+
+        invalid = sorted(
+            index for index in indices if index < -neuron_count or index >= neuron_count
+        )
+        if invalid:
+            raise ValueError(
+                f"Neuron indices {invalid} are outside layer {layer_id}'s "
+                f"valid range [-{neuron_count}, {neuron_count - 1}]."
+            )
+        return indices
+
+    def add_neurons(self, layer_id: int, count: int = 1) -> None:
+        """Append ``count`` neurons and propagate the change through the graph."""
+        self.get_layer_by_id(layer_id)
+        if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+            raise ValueError("count must be a positive integer.")
+        self.operate(
+            layer_id=layer_id,
+            neuron_indices=set(range(count)),
+            op_type=ArchitectureNeuronsOpType.ADD,
+        )
+
+    def prune_neurons(self, layer_id: int, neuron_indices: Iterable[int] | int) -> None:
+        """Remove selected neurons and update dependent layers."""
+        indices = self._validated_neuron_indices(
+            layer_id, neuron_indices, allow_empty=False
+        )
+        self.operate(
+            layer_id=layer_id,
+            neuron_indices=indices,
+            op_type=ArchitectureNeuronsOpType.PRUNE,
+        )
+
+    def freeze_neurons(
+        self,
+        layer_id: int,
+        neuron_indices: Optional[Iterable[int] | int] = None,
+    ) -> None:
+        """Freeze selected neurons idempotently (all when omitted)."""
+        self._set_neurons_frozen(layer_id, neuron_indices, frozen=True)
+
+    def unfreeze_neurons(
+        self,
+        layer_id: int,
+        neuron_indices: Optional[Iterable[int] | int] = None,
+    ) -> None:
+        """Unfreeze selected neurons idempotently (all when omitted)."""
+        self._set_neurons_frozen(layer_id, neuron_indices, frozen=False)
+
+    def _set_neurons_frozen(
+        self,
+        layer_id: int,
+        neuron_indices: Optional[Iterable[int] | int],
+        *,
+        frozen: bool,
+    ) -> None:
+        indices = self._validated_neuron_indices(
+            layer_id, neuron_indices, allow_empty=True
+        )
+        layer = self.get_layer_by_id(layer_id)
+        if not hasattr(layer, "weight") or layer.weight is None:
+            raise ValueError(
+                f"Layer {layer_id} has no learnable weights to freeze. "
+                "Select a learnable layer from get_model_graph()."
+            )
+        neuron_count = self._neuron_count(layer, "out_neurons") or 0
+        selected = (
+            {index % neuron_count for index in indices}
+            if indices
+            else set(range(neuron_count))
+        )
+        weight_lrs = getattr(layer, "neuron_2_lr", {}).get("weight", {})
+        currently_frozen = {
+            index for index in selected if float(weight_lrs.get(index, 1.0)) == 0.0
+        }
+        indices_to_toggle = (
+            selected - currently_frozen if frozen else currently_frozen
+        )
+        if not indices_to_toggle:
+            return
+        self.operate(
+            layer_id=layer_id,
+            neuron_indices=indices_to_toggle,
+            op_type=ArchitectureNeuronsOpType.FREEZE,
+        )
+
+    def reset_neurons(
+        self,
+        layer_id: int,
+        neuron_indices: Optional[Iterable[int] | int] = None,
+    ) -> None:
+        """Reinitialize selected neurons (all when omitted)."""
+        indices = self._validated_neuron_indices(
+            layer_id, neuron_indices, allow_empty=True
+        )
+        self.operate(
+            layer_id=layer_id,
+            neuron_indices=indices,
+            op_type=ArchitectureNeuronsOpType.RESET,
+        )
+
+    def perturb_neurons(
+        self,
+        layer_id: int,
+        neuron_indices: Optional[Iterable[int] | int] = None,
+        *,
+        ratio: float = 0.1,
+    ) -> None:
+        """Perturb selected weights by a relative random amount."""
+        if not isinstance(ratio, (int, float)) or isinstance(ratio, bool) or not 0 < ratio < 1:
+            raise ValueError("ratio must be strictly between 0 and 1.")
+        indices = self._validated_neuron_indices(
+            layer_id, neuron_indices, allow_empty=True
+        )
+        self.operate(
+            layer_id=layer_id,
+            neuron_indices=indices,
+            op_type=ArchitectureNeuronsOpType.RESET,
+            perturbation_ratio=float(ratio),
+        )
 
     def register_dependencies(
         self,


### PR DESCRIPTION
## Summary

- add a versioned, JSON-serializable model graph and per-layer/per-neuron inspection API
- add validated dependency-aware helpers for add, prune, freeze, unfreeze, reset, and perturb operations
- make freeze/unfreeze idempotent at the public API boundary
- document the model graph ontology, dependency types, and editing workflow
- add regression coverage for graph serialization, live structural edits, frozen state, and invalid targets

## Why

Issue #267 identifies the existing modelling implementation as difficult to discover and use. The dependency engine and neuron operations already exist, but callers must understand internal layer ids, enums, and `operate()` semantics. This PR exposes the first vertical API slice requested by the issue while preserving the existing Torch FX/ONNX dependency machinery.

This intentionally does not close #267. The deeper index-mapping, hardcoding, monitoring, lineage, and broad architecture coverage tracked by #6, #7, and #8 remain follow-up work.

## Developer impact

A wrapped model created with `compute_dependencies=True` can now describe its editable graph through `get_model_graph()` / `get_layer_info()` and perform validated edits through named methods. Structural graph inspection stays lightweight by default; per-neuron records are opt-in for whole-graph responses.

## Validation

- `38 passed, 7 skipped` across focused model, interface, constraint, and trainer-service tests
- Ruff CI error rules, `compileall`, and `git diff --check` pass
- Full suite reached `949 passed, 131 skipped`; remaining local failures/errors require unavailable MNIST downloads, the separately built/gitignored Studio bundle, or restricted local port/multiprocessing capabilities
